### PR TITLE
Multiple optimizations

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,6 +1,7 @@
 Component,Origin,License,Copyright
 main,slf4j,mit,QOS.ch
 main,libddwaf,apache-2.0,DataDog
+main,weak-lock-free,apache-2.0,Rafael Winterhalter
 tests,junit,epl-1.0,various
 tests,ant,apache-2.0,Apache Software Foundation
 tests,groovy,apache-2.0,various

--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,7 @@ configurations {
 def SLF4J_VERSION = '1.7.30'
 dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-api', version: SLF4J_VERSION
+    implementation group: 'com.blogspot.mydailyjava', name: 'weak-lock-free', version: '0.17'
 
     testRuntimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: SLF4J_VERSION
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.2'

--- a/dl_dbgsyms
+++ b/dl_dbgsyms
@@ -39,8 +39,8 @@ function extract {
 function main {
   local readonly version=$1
   dl_zip $version
-  extract $version linux_64_glibc/libsqreen_jni
-  extract $version linux_64/libddwaf
+  extract $version linux/x86_64/glibc/libsqreen_jni
+  extract $version linux/x86_64/libddwaf
 }
 
 main $1

--- a/src/main/c/jni/io_sqreen_powerwaf_Additive.h
+++ b/src/main/c/jni/io_sqreen_powerwaf_Additive.h
@@ -18,9 +18,9 @@ JNIEXPORT jlong JNICALL Java_io_sqreen_powerwaf_Additive_initAdditive
 /*
  * Class:     io_sqreen_powerwaf_Additive
  * Method:    runAdditive
- * Signature: (Ljava/util/Map;Lio/sqreen/powerwaf/Powerwaf$Limits;Lio/sqreen/powerwaf/PowerwafMetrics;)Lio/sqreen/powerwaf/Powerwaf$ResultWithData;
+ * Signature: (Ljava/lang/Object;Lio/sqreen/powerwaf/Powerwaf$Limits;Lio/sqreen/powerwaf/PowerwafMetrics;)Lio/sqreen/powerwaf/Powerwaf$ResultWithData;
  */
-JNIEXPORT jobject JNICALL Java_io_sqreen_powerwaf_Additive_runAdditive__Ljava_util_Map_2Lio_sqreen_powerwaf_Powerwaf_00024Limits_2Lio_sqreen_powerwaf_PowerwafMetrics_2
+JNIEXPORT jobject JNICALL Java_io_sqreen_powerwaf_Additive_runAdditive__Ljava_lang_Object_2Lio_sqreen_powerwaf_Powerwaf_00024Limits_2Lio_sqreen_powerwaf_PowerwafMetrics_2
   (JNIEnv *, jobject, jobject, jobject, jobject);
 
 /*

--- a/src/main/c/jni/io_sqreen_powerwaf_Powerwaf.h
+++ b/src/main/c/jni/io_sqreen_powerwaf_Powerwaf.h
@@ -42,9 +42,9 @@ JNIEXPORT jobject JNICALL Java_io_sqreen_powerwaf_Powerwaf_runRules__Lio_sqreen_
 /*
  * Class:     io_sqreen_powerwaf_Powerwaf
  * Method:    runRules
- * Signature: (Lio/sqreen/powerwaf/PowerwafHandle;Ljava/util/Map;Lio/sqreen/powerwaf/Powerwaf$Limits;Lio/sqreen/powerwaf/PowerwafMetrics;)Lio/sqreen/powerwaf/Powerwaf$ResultWithData;
+ * Signature: (Lio/sqreen/powerwaf/PowerwafHandle;Ljava/lang/Object;Lio/sqreen/powerwaf/Powerwaf$Limits;Lio/sqreen/powerwaf/PowerwafMetrics;)Lio/sqreen/powerwaf/Powerwaf$ResultWithData;
  */
-JNIEXPORT jobject JNICALL Java_io_sqreen_powerwaf_Powerwaf_runRules__Lio_sqreen_powerwaf_PowerwafHandle_2Ljava_util_Map_2Lio_sqreen_powerwaf_Powerwaf_00024Limits_2Lio_sqreen_powerwaf_PowerwafMetrics_2
+JNIEXPORT jobject JNICALL Java_io_sqreen_powerwaf_Powerwaf_runRules__Lio_sqreen_powerwaf_PowerwafHandle_2Ljava_lang_Object_2Lio_sqreen_powerwaf_Powerwaf_00024Limits_2Lio_sqreen_powerwaf_PowerwafMetrics_2
   (JNIEnv *, jclass, jobject, jobject, jobject, jobject);
 
 /*

--- a/src/main/c/powerwaf_jni.c
+++ b/src/main/c/powerwaf_jni.c
@@ -142,6 +142,9 @@ jclass *number_cls = &number_longValue.class_glob;
 static struct j_method _boolean_booleanValue;
 static jclass *_boolean_cls = &_boolean_booleanValue.class_glob;
 
+// MapIterableWithSize
+static jclass _miws_cls;
+
 static struct j_method _hashmap_init;
 static struct j_method _map_put;
 struct j_method map_entryset;
@@ -596,10 +599,10 @@ end:
 /*
  * Class:     io_sqreen_powerwaf_Powerwaf
  * Method:    runRules
- * Signature: (Lio/sqreen/powerwaf/PowerwafHandle;Ljava/util/Map;Lio/sqreen/powerwaf/Powerwaf$Limits;)Lio/sqreen/powerwaf/Powerwaf$ResultWithData;
+ * Signature: (Lio/sqreen/powerwaf/PowerwafHandle;Ljava/util/Object;Lio/sqreen/powerwaf/Powerwaf$Limits;)Lio/sqreen/powerwaf/Powerwaf$ResultWithData;
  */
 JNIEXPORT jobject JNICALL
-Java_io_sqreen_powerwaf_Powerwaf_runRules__Lio_sqreen_powerwaf_PowerwafHandle_2Ljava_util_Map_2Lio_sqreen_powerwaf_Powerwaf_00024Limits_2Lio_sqreen_powerwaf_PowerwafMetrics_2(
+Java_io_sqreen_powerwaf_Powerwaf_runRules__Lio_sqreen_powerwaf_PowerwafHandle_2Ljava_lang_Object_2Lio_sqreen_powerwaf_Powerwaf_00024Limits_2Lio_sqreen_powerwaf_PowerwafMetrics_2(
         JNIEnv *env, jclass clazz, jobject handle_obj, jobject parameters,
         jobject limits_obj, jobject metrics_obj)
 {
@@ -811,10 +814,10 @@ err:
  * Class:     io_sqreen_powerwaf_Additive
  * Method:    runAdditive
  * Signature:
- * (Ljava/util/Map;Lio/sqreen/powerwaf/Powerwaf$Limits;)Lio/sqreen/powerwaf/Powerwaf$ResultWithData;
+ * (Ljava/lang/Object;Lio/sqreen/powerwaf/Powerwaf$Limits;)Lio/sqreen/powerwaf/Powerwaf$ResultWithData;
  */
 JNIEXPORT jobject JNICALL
-Java_io_sqreen_powerwaf_Additive_runAdditive__Ljava_util_Map_2Lio_sqreen_powerwaf_Powerwaf_00024Limits_2Lio_sqreen_powerwaf_PowerwafMetrics_2(
+Java_io_sqreen_powerwaf_Additive_runAdditive__Ljava_lang_Object_2Lio_sqreen_powerwaf_Powerwaf_00024Limits_2Lio_sqreen_powerwaf_PowerwafMetrics_2(
         JNIEnv *env, jobject this, jobject parameters, jobject limits_obj,
         jobject metrics_obj)
 {
@@ -1128,17 +1131,18 @@ static bool _cache_single_class_weak(JNIEnv *env,
 
 static bool _cache_classes(JNIEnv *env)
 {
-  return _cache_single_class_weak(env, "java/lang/RuntimeException",
-                                  &jcls_rte) &&
-         _cache_single_class_weak(env, "java/lang/IllegalArgumentException",
-                                  &jcls_iae) &&
-         _cache_single_class_weak(env, "java/lang/CharSequence",
-                                  &charSequence_cls) &&
-         _cache_single_class_weak(env, "java/nio/Buffer",
-                                  &buffer_cls) &&
-         _cache_single_class_weak(env, "java/nio/CharBuffer",
-                                  &charBuffer_cls) &&
-         _cache_single_class_weak(env, "java/lang/String", &string_cls);
+    return _cache_single_class_weak(env, "java/lang/RuntimeException",
+                                    &jcls_rte) &&
+           _cache_single_class_weak(env, "java/lang/IllegalArgumentException",
+                                    &jcls_iae) &&
+           _cache_single_class_weak(env, "java/lang/CharSequence",
+                                    &charSequence_cls) &&
+           _cache_single_class_weak(env, "java/nio/Buffer", &buffer_cls) &&
+           _cache_single_class_weak(env, "java/nio/CharBuffer",
+                                    &charBuffer_cls) &&
+           _cache_single_class_weak(env, "java/lang/String", &string_cls) &&
+           _cache_single_class_weak(
+                   env, "io/sqreen/powerwaf/MapIterableWithSize", &_miws_cls);
 }
 
 static void _dispose_of_weak_classes(JNIEnv *env)
@@ -1154,6 +1158,7 @@ static void _dispose_of_weak_classes(JNIEnv *env)
     DESTROY_CLASS_REF(charSequence_cls)
     DESTROY_CLASS_REF(buffer_cls)
     DESTROY_CLASS_REF(charBuffer_cls)
+    DESTROY_CLASS_REF(_miws_cls)
     // leave jcls_rte for last in OnUnload; we might still need it
 }
 
@@ -1487,6 +1492,10 @@ static ddwaf_object _convert_checked_ex(JNIEnv *env, bool use_bools,
         JNI(DeleteLocalRef, clazz);
     }
 
+    // shared between two branches
+    jobject entry_set = NULL;
+    jobject entry_set_it;
+
     if (JNI(IsSameObject, obj, NULL)) {
         // replace NULLs with empty maps.
         // DDWAF_OBJ_NULL is actually invalid; it can't be added to containers
@@ -1526,6 +1535,18 @@ static ddwaf_object _convert_checked_ex(JNIEnv *env, bool use_bools,
                 goto error;
             }
         }
+    } else if (JNI(IsInstanceOf, obj, _miws_cls)) {
+        ddwaf_object_map(&result);
+        if (rec_level >= lims->max_depth) {
+            JAVA_LOG(DDWAF_LOG_DEBUG,
+                     "Leaving map empty because max depth of %d "
+                     "has been reached",
+                     lims->max_depth);
+            goto early_return;
+        }
+        JAVA_CALL(entry_set_it, iterable_iterator, obj);
+        goto iterator_map_entry;
+
     } else if (JNI(IsInstanceOf, obj, *map_cls)) {
         ddwaf_object_map(&result); // can't fail
         if (rec_level >= lims->max_depth) {
@@ -1536,10 +1557,10 @@ static ddwaf_object _convert_checked_ex(JNIEnv *env, bool use_bools,
             goto early_return;
         }
 
-        jobject entry_set, entry_set_it;
         JAVA_CALL(entry_set, map_entryset, obj);
         JAVA_CALL(entry_set_it, iterable_iterator, entry_set);
 
+iterator_map_entry:
         while (JNI(CallBooleanMethod, entry_set_it, iterator_hasNext.meth_id)) {
             if (JNI(ExceptionCheck)) {
                 goto error;
@@ -1592,7 +1613,9 @@ static ddwaf_object _convert_checked_ex(JNIEnv *env, bool use_bools,
         }
 
         JNI(DeleteLocalRef, entry_set_it);
-        JNI(DeleteLocalRef, entry_set);
+        if (entry_set) {
+            JNI(DeleteLocalRef, entry_set);
+        }
 
     } else if (JNI(IsInstanceOf, obj, *iterable_cls)) {
         ddwaf_object_array(&result);

--- a/src/main/java/io/sqreen/powerwaf/Additive.java
+++ b/src/main/java/io/sqreen/powerwaf/Additive.java
@@ -48,7 +48,7 @@ public final class Additive implements Closeable {
     private static native long initAdditive(PowerwafHandle handle);
 
     private native Powerwaf.ResultWithData runAdditive(
-            Map<String, Object> parameters, Powerwaf.Limits limits, PowerwafMetrics metrics) throws AbstractPowerwafException;
+            Object parameters, Powerwaf.Limits limits, PowerwafMetrics metrics) throws AbstractPowerwafException;
 
     private native Powerwaf.ResultWithData runAdditive(
             ByteBuffer firstPWArgsBuffer, Powerwaf.Limits limits, PowerwafMetrics metrics) throws AbstractPowerwafException;
@@ -70,9 +70,30 @@ public final class Additive implements Closeable {
      * @return                              execution results
      * @throws AbstractPowerwafException    rethrow from native code, timeout or param serialization failure
      */
-    public Powerwaf.ResultWithData run(Map<String, Object> parameters,
+    public Powerwaf.ResultWithData run(Map<?, Object> parameters,
                                        Powerwaf.Limits limits,
                                        PowerwafMetrics metrics) throws AbstractPowerwafException {
+        return run((Object) parameters, limits, metrics);
+    }
+
+    /**
+     * Push params to PowerWAF with given limits
+     *
+     * @param parameters                    data to push to PowerWAF
+     * @param limits                        request execution limits
+     * @param metrics                       a metrics collector, or null
+     * @return                              execution results
+     * @throws AbstractPowerwafException    rethrow from native code, timeout or param serialization failure
+     */
+    public Powerwaf.ResultWithData run(MapIterableWithSize<?> parameters,
+                                       Powerwaf.Limits limits,
+                                       PowerwafMetrics metrics) throws AbstractPowerwafException {
+        return run((Object) parameters, limits, metrics);
+    }
+
+    private Powerwaf.ResultWithData run(Object parameters,
+                                        Powerwaf.Limits limits,
+                                        PowerwafMetrics metrics) throws AbstractPowerwafException {
         if (limits == null) {
             throw new IllegalArgumentException("limits must be provided");
         }

--- a/src/main/java/io/sqreen/powerwaf/MapIterableWithSize.java
+++ b/src/main/java/io/sqreen/powerwaf/MapIterableWithSize.java
@@ -1,0 +1,7 @@
+package io.sqreen.powerwaf;
+
+import java.util.Map;
+
+public interface MapIterableWithSize<T> extends Iterable<Map.Entry<T, Object>> {
+    int size();
+}

--- a/src/main/java/io/sqreen/powerwaf/NativeStringAddressable.java
+++ b/src/main/java/io/sqreen/powerwaf/NativeStringAddressable.java
@@ -1,0 +1,7 @@
+package io.sqreen.powerwaf;
+
+import java.nio.ByteBuffer;
+
+public interface NativeStringAddressable extends CharSequence {
+    ByteBuffer getNativeStringBuffer();
+}

--- a/src/main/java/io/sqreen/powerwaf/Powerwaf.java
+++ b/src/main/java/io/sqreen/powerwaf/Powerwaf.java
@@ -131,7 +131,7 @@ public final class Powerwaf {
                                           PowerwafMetrics metrics) throws AbstractPowerwafException;
 
     static native ResultWithData runRules(PowerwafHandle handle,
-                                          Map<String, Object> parameters,
+                                          Object parameters,
                                           Limits limits,
                                           PowerwafMetrics metrics) throws AbstractPowerwafException;
 

--- a/src/main/java/io/sqreen/powerwaf/PowerwafContext.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafContext.java
@@ -110,8 +110,20 @@ public class PowerwafContext implements Closeable {
     }
 
     public Powerwaf.ResultWithData runRules(Map<String, Object> parameters,
-                                            Powerwaf.Limits limits,
-                                            PowerwafMetrics metrics) throws AbstractPowerwafException {
+                                             Powerwaf.Limits limits,
+                                             PowerwafMetrics metrics) throws AbstractPowerwafException {
+        return runRules((Object) parameters, limits, metrics);
+    }
+
+    public Powerwaf.ResultWithData runRules(MapIterableWithSize<?> parameters,
+                                             Powerwaf.Limits limits,
+                                             PowerwafMetrics metrics) throws AbstractPowerwafException {
+        return runRules((Object) parameters, limits, metrics);
+    }
+
+    private Powerwaf.ResultWithData runRules(Object parameters,
+                                             Powerwaf.Limits limits,
+                                             PowerwafMetrics metrics) throws AbstractPowerwafException {
         this.readLock.lock();
         try {
             checkIfOnline();

--- a/src/test/groovy/io/sqreen/powerwaf/InvalidInvocationTests.groovy
+++ b/src/test/groovy/io/sqreen/powerwaf/InvalidInvocationTests.groovy
@@ -101,8 +101,9 @@ class InvalidInvocationTests implements ReactiveTrait {
         ByteBufferSerializer serializer = new ByteBufferSerializer(limits)
         serializer.serialize([a: 'b']).withCloseable { lease ->
             ByteBuffer buffer = lease.firstPWArgsByteBuffer
+            buffer.limit(buffer.capacity())
+            buffer.position(ByteBufferSerializer.SIZEOF_PWARGS)
             def slice = buffer.slice()
-            slice.position(ByteBufferSerializer.SIZEOF_PWARGS)
             shouldFail(InvalidObjectPowerwafException) {
                 additive.runAdditive(slice, limits, metrics)
             }

--- a/src/test/groovy/io/sqreen/powerwaf/LimitsTests.groovy
+++ b/src/test/groovy/io/sqreen/powerwaf/LimitsTests.groovy
@@ -62,6 +62,18 @@ class LimitsTests implements PowerwafTrait {
     }
 
     @Test
+    void 'maxDepth is respected — MapIterableWithSize variant'() {
+        ctx = ctxWithArachniAtom
+        maxDepth = 3
+
+        Powerwaf.ResultWithData awd = runRules(asMiws(a: 'Arachni'))
+        assertThat awd.result, is(Powerwaf.Result.MATCH)
+
+        awd = runRules([a: asMiws(a: 'Arachni')])
+        assertThat awd.result, is(Powerwaf.Result.OK)
+    }
+
+    @Test
     void 'maxElements is respected'() {
         ctx = ctxWithArachniAtom
         maxElements = 5
@@ -194,5 +206,12 @@ class LimitsTests implements PowerwafTrait {
 
         def json = slurper.parseText(res.data)
         assertThat json.ret_code, hasItem(is(new TimeoutPowerwafException().code))
+    }
+
+    private MapIterableWithSize asMiws(Map m) {
+        [
+                size: { -> m.size() },
+                iterator: { -> m.entrySet().iterator() }
+        ] as MapIterableWithSize
     }
 }


### PR DESCRIPTION
* Introduce two types to aid efficient serialization: `MapIterableWithSize` and `NativeStringAddressable`. The first is an entry iterable that doesn't need to be iterated twice, as it has a size(). This alleviates the need to implement `Map`. The second is a `CharSequence` that also provides a nul-terminated byte buffer with the UTF-8 representation of the string.
* Always allocate the initial object in the beginning of the first segment. On a second WAF run, the initial object is replaced. This is allowed by the WAF (the root element, and only the root element, can be replaced between runs), saves a little bit of space and avoids creating a new ByteBuffer slice() on each run.
* Save memory by not caching `PWArgsBuffer` objects. To avoid creating many of them, they are reused when possible.
* Reduce the number of native calls to getByteBufferAddress.
* Introduce a memory stats function.