### PR TITLE
Split build and test stages

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -450,6 +450,10 @@ jobs:
             os: linux
             arch: x86_64
             dockerfile: ci/manylinux/x86_64
+          - runs-on: ubuntu-20.04
+            os: linux
+            arch: aarch64
+            dockerfile: ci/manylinux/aarch64
           - runs-on: macos-11
           - runs-on: macos-12
           - runs-on: macos-13
@@ -471,6 +475,9 @@ jobs:
       with:
         name: build_dir
         path: build
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      if: ${{ matrix.os == 'linux' && matrix.os == 'aarch64' }}
     - name: Build docker image
       run: ci/build build-docker-image --os ${{ matrix.os }} --arch ${{ matrix.arch }} --docker-image ${{ matrix.dockerfile }}
       if: ${{ matrix.os == 'linux' }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -459,8 +459,9 @@ jobs:
           - runs-on: macos-12
           - runs-on: macos-13
           - runs-on: macos-14
-          - runs-on: macos-13-arm64
-          - runs-on: macos-14-arm64
+          # macos arm64
+          - runs-on: macos-13-xlarge
+          - runs-on: macos-14-xlarge
           - runs-on: windows-2019
           - runs-on: windows-2022
           # TBD: linux aarch64

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -444,6 +444,7 @@ jobs:
     needs:
       - Jar_File_Stage_build_jar
     strategy:
+      fail-fast: false
       matrix:
         include:
           - runs-on: ubuntu-20.04

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -447,6 +447,9 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-20.04
+            os: linux
+            arch: x86_64
+            dockerfile: ci/manylinux/x86_64
           - runs-on: macos-11
           - runs-on: macos-12
           - runs-on: macos-13
@@ -468,8 +471,15 @@ jobs:
       with:
         name: build_dir
         path: build
-    - name: Run tests
+    - name: Build docker image
+      run: ci/build build-docker-image --os ${{ matrix.os }} --arch ${{ matrix.arch }} --docker-image ${{ matrix.dockerfile }}
+      if: ${{ matrix.os == 'linux' }}
+    - name: Run tests (docker)
+      run: ci/build run-tests-in-docker --os ${{ matrix.os }} --arch ${{ matrix.arch }} --docker-image ${{ matrix.dockerfile }}
+      if: ${{ matrix.os == 'linux' }}
+    - name: Run tests (no docker)
       run: ci/build run-tests
+      if: ${{ matrix.os != 'linux' }}
   Publish:
     name: Publish
     runs-on: ubuntu-20.04

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -478,7 +478,7 @@ jobs:
         path: build
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
-      if: ${{ matrix.os == 'linux' && matrix.os == 'aarch64' }}
+      if: ${{ matrix.os == 'linux' && matrix.arch == 'aarch64' }}
     - name: Build docker image
       run: ci/build build-docker-image --os ${{ matrix.os }} --arch ${{ matrix.arch }} --docker-image ${{ matrix.dockerfile }}
       if: ${{ matrix.os == 'linux' }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -450,8 +450,20 @@ jobs:
             os: linux
             arch: x86_64
             libc: glibc
+          - runs-on: ubuntu-20.04
+            os: linux
+            arch: x86_64
+            libc: musl
+          # TBD: linux aarch64
+          # TBD: macos
+          # TBD: windows
     runs-on: ${{ matrix.runs-on }}
     steps:
+    - uses: actions/checkout@v4
+      name: Checkout
+      with:
+        submodules: recursive
+        clean: true
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -447,16 +447,15 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-20.04
-            os: linux
-            arch: x86_64
-            libc: glibc
-          - runs-on: ubuntu-20.04
-            os: linux
-            arch: x86_64
-            libc: musl
+          - runs-on: macos-11
+          - runs-on: macos-12
+          - runs-on: macos-13
+          - runs-on: macos-14
+          - runs-on: macos-13-arm64
+          - runs-on: macos-14-arm64
+          - runs-on: windows-2019
+          - runs-on: windows-2022
           # TBD: linux aarch64
-          # TBD: macos
-          # TBD: windows
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v4
@@ -470,7 +469,7 @@ jobs:
         name: build_dir
         path: build
     - name: Run tests
-      run: ci/build run-tests --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
+      run: ci/build run-tests
   Publish:
     name: Publish
     runs-on: ubuntu-20.04

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -67,8 +67,6 @@ jobs:
         run: ci/build build-libddwaf --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
       - name: Build JNI bindings
         run: ci/build build-bindings --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
-      - name: Run tests
-        run: ci/build run-tests --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -93,9 +91,6 @@ jobs:
         run: ci/build build-libddwaf --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
       - name: Build JNI bindings
         run: ci/build build-bindings --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
-      # No arm64 tests for now (will do with macos-13)
-      #- name: Run tests
-      #  run: ci/build run-tests --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -133,9 +128,6 @@ jobs:
         run: cmake --build . --target install
       - name: Build JNI bindings
         run: ci/build build-bindings --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
-        shell: bash
-      - name: Run tests
-        run: ci/build run-tests --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
         shell: bash
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
@@ -218,8 +210,6 @@ jobs:
         run: ci/build build-docker-image --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
       - name: Build JNI bindings
         run: ci/build build-bindings-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
-      - name: Run tests
-        run: ci/build run-tests-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -251,8 +241,6 @@ jobs:
         run: ci/build build-docker-image --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
       - name: Build JNI bindings
         run: ci/build build-bindings-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
-      - name: Run tests
-        run: ci/build run-tests-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -286,8 +274,6 @@ jobs:
         run: ci/build build-docker-image --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
       - name: Build JNI bindings
         run: ci/build build-bindings-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
-      - name: Run tests
-        run: ci/build run-tests-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -321,8 +307,6 @@ jobs:
         run: ci/build build-docker-image --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
       - name: Build JNI bindings
         run: ci/build build-bindings-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
-      - name: Run tests
-        run: ci/build run-tests-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -369,7 +353,7 @@ jobs:
           LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.8 \
           ./gradlew --build-cache -x buildNativeLib --info test
   Jar_File_Stage_build_jar:
-    name: Build & Publish
+    name: Build
     runs-on: ubuntu-20.04
     needs:
       - Native_binaries_Stage_macos_x86_64
@@ -449,9 +433,49 @@ jobs:
       with:
         path: ${{ env.tempdir }}/packages
         name: libsqreen_jni_jar
-    - name: Publish artifacts to S3
-      run: ./gradlew publish
-      env:
-        AWS_ACCESS_KEY_ID: AKIA5VR734GFSK4FR2PD
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      if: (success() && contains(github.ref, 'refs/tags/v'))
+    - name: Publish artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        path: build
+        name: build_dir
+
+  Test:
+    name: Test
+    needs:
+      - Jar_File_Stage_build_jar
+    strategy:
+      matrix:
+        include:
+          - runs-on: ubuntu-20.04
+            os: linux
+            arch: x86_64
+            libc: glibc
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: build_dir
+        path: build
+    - name: Run tests
+      run: ci/build run-tests --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
+  Publish:
+    name: Publish
+    runs-on: ubuntu-20.04
+    needs:
+      - Jar_File_Stage_build_jar
+      - Test
+    if: contains(github.ref, 'refs/tags/v')
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: build_dir
+        path: build
+    - name: Publish artifacts to S3ç
+      # DEBUG guard rails
+      run: false
+      #run: ./gradlew publish
+      #env:
+      #  AWS_ACCESS_KEY_ID: AKIA5VR734GFSK4FR2PD
+      #  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/ci/build
+++ b/ci/build
@@ -5,7 +5,7 @@ readonly OUTPUT_NATIVE_LIBS_DIR="build/native_libs"
 
 function cmd_build-docker-image() {
     echo "Building docker image..."
-    docker build --platform "$OS/$ARCH" "$DOCKER_IMAGE" -t "libddwaf-build-$LIBC"
+    docker build --platform "$OS/$ARCH" "$DOCKER_IMAGE" -t "libddwaf-build"
 }
 
 function cmd_build-libddwaf() {
@@ -72,7 +72,7 @@ function cmd_build-bindings-in-docker() {
         --user "$(id -u):$(id -g)" \
         -v "$(pwd):/work" \
         -w /work \
-        "libddwaf-build-$LIBC" \
+        "libddwaf-build" \
         ./ci/build build-bindings --os $OS --arch $ARCH --libc $LIBC
 }
 
@@ -146,8 +146,8 @@ function cmd_run-tests-in-docker() {
         --user "$(id -u):$(id -g)" \
         -v "$(pwd):/work" \
         -w /work \
-        "libddwaf-build-$LIBC" \
-        ./ci/build run-tests --os "$OS" --arch "$ARCH" --libc "${LIBC:-}"
+        "libddwaf-build" \
+        ./ci/build run-tests
 }
 
 function cmd_run-tests() {
@@ -186,6 +186,10 @@ while [[ $# -gt 0 ]]; do
             DEBUG=true
             shift
             ;;
+        --docker-image)
+            DOCKER_IMAGE="$2"
+            shift 2
+            ;;
         *)
             echo "Unknown option: $1"
             exit 1
@@ -193,16 +197,19 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-case "${OS:-}-${ARCH:-}-${LIBC:-}" in
-    linux-*-glibc)
-        DOCKER_IMAGE="ci/manylinux/$ARCH"
-        ;;
-    linux-*-musl)
-        DOCKER_IMAGE="ci/alpine"
-        ;;
-    *)
-        ;;
-esac
+if [[ -z ${DOCKER_IMAGE:-} ]]; then
+    case "${OS:-}-${ARCH:-}-${LIBC:-}" in
+        linux-*-glibc)
+            DOCKER_IMAGE="ci/manylinux/$ARCH"
+            ;;
+        linux-*-musl)
+            DOCKER_IMAGE="ci/alpine"
+            ;;
+        *)
+            DOCKER_IMAGE=
+            ;;
+    esac
+fi
 
 # check if function cmd_$COMMAND exists, and then run it:
 if declare -F "cmd_$COMMAND" &> /dev/null; then


### PR DESCRIPTION
Split build and test stages. Builds can quickly run first, then generate the final artifact, and then run all tests. Tests may run for more operating system combinations than builds.