### PR TITLE
Simplify build scripts

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,12 +14,18 @@ jobs:
   Coverage:
     runs-on: ubuntu-22.04
     if: "!(contains(github.ref, 'refs/tags/v'))"
+    env:
+      os: linux
+      arch: x86_64
+      libc: "glibc"
     steps:
       - uses: actions/checkout@v4
         name: Checkout
         with:
           submodules: recursive
           clean: true
+      - name: Build libddwaf
+        run: ci/build build-libddwaf --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}' --debug
       - name: Cache Gradle artifacts
         uses: actions/cache@v2
         with:
@@ -29,14 +35,6 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Build libddwdaf
-        run: |
-          mkdir libddwaf/Debug
-          cd libddwaf/Debug
-          cmake .. -DCMAKE_BUILD_TYPE=Debug
-          VERBOSE=1 make -j
-          DESTDIR=out make install
-          cd ../..
       - name: Build and test
         run: |
           ./gradlew check jacocoTestReport
@@ -50,192 +48,59 @@ jobs:
           flags: helper
           verbose: true
           files: build/coverage.xml,build/reports/jacoco/test/jacocoTestReport.xml
+
   Native_binaries_Stage_macos_x86_64:
     name: MacOS x86_64
     runs-on: macOS-12
     env:
-      generator: Unix Makefiles
-      shlib_prefix: lib
-      shlib_ext: dylib
-      debug_ext: dylib.dwarf
+      os: macos
+      arch: x86_64
+      libc: ""
       artifactsuff: macos-x86_64
-      libdir: macos/x86_64
     steps:
-    - uses: actions/checkout@v4
-      name: Checkout
-      with:
-        submodules: recursive
-        clean: true
-    - name: Create Build Directory for libddwaf
-      run: cmake -E make_directory "${{ env.tempdir }}/buildPW"
-    - name: Create Build Directory for JNI binding
-      run: cmake -E make_directory "${{ env.tempdir }}/buildAG"
-    - name: Create Packages Directory
-      run: cmake -E make_directory ${{ env.tempdir }}/packages
-    - name: Generate Build Scripts for libddwaf
-      run: |
-        cmake -DCMAKE_BUILD_TYPE=${{ env.buildType }} \
-          -DLIBDDWAF_BUILD_STATIC=0 \
-          -DCMAKE_C_FLAGS="-mmacosx-version-min=11.6 -fno-omit-frame-pointer" \
-          -DCMAKE_CXX_FLAGS="-mmacosx-version-min=11.6 -fno-omit-frame-pointer" \
-          -DCMAKE_INSTALL_PREFIX='${{ env.tempdir }}/out' \
-          -G '${{ env.generator }}' '${{ github.workspace }}/libddwaf'
-      working-directory: ${{ env.tempdir }}/buildPW
-    - name: Build Binaries for libddwaf
-      run: cmake --build . --verbose
-      working-directory: ${{ env.tempdir }}/buildPW
-    - name: Install Binaries for libddwaf
-      run: cmake --build . --target install
-      working-directory: ${{ env.tempdir }}/buildPW
-    - name: Generate Build Scripts for JNI binding
-      run: |
-        cmake -DCMAKE_BUILD_TYPE=${{ env.buildType }} \
-          -DCMAKE_PREFIX_PATH='${{ env.tempdir }}/out/share/cmake/libddwaf/' \
-          -DCMAKE_C_FLAGS="-mmacosx-version-min=11.6 -fno-omit-frame-pointer" \
-          -G "${{ env.generator }}" ${{ github.workspace }}
-      working-directory: ${{ env.tempdir }}/buildAG
-    - name: Build Binaries for JNI Binding
-      run: cmake --build . --verbose
-      working-directory: ${{ env.tempdir }}/buildAG
-    - name: Copy libddwaf binaries to packages
-      run: |
-        cmake -E copy ${{ env.shlib_prefix }}ddwaf.${{ env.shlib_ext }} \
-          ${{ env.shlib_prefix }}ddwaf.${{ env.debug_ext }} \
-          ${{ env.tempdir }}/packages
-      working-directory: ${{ env.tempdir }}/buildPW
-    - name: Copy libddwaf binding binaries to native_libs (testing)
-      run: |
-        cmake -E copy ${{ env.shlib_prefix }}ddwaf.${{ env.shlib_ext }} \
-          ${{ env.shlib_prefix }}ddwaf.${{ env.debug_ext }} \
-          ${{ github.workspace }}/native_libs/${{ env.libdir }}
-      working-directory: ${{ env.tempdir }}/buildPW
-    - name: Copy JNI binding binaries to packages
-      run: |
-        cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} \
-          ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} \
-          ${{ env.tempdir }}/packages
-      working-directory: ${{ env.tempdir }}/buildAG
-    - name: Copy JNI binding binaries to native_libs (testing)
-      run: |
-        cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} \
-          ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} \
-          ${{ github.workspace }}/native_libs/${{ env.libdir }}
-      working-directory: ${{ env.tempdir }}/buildAG
-    - name: Cache Gradle artifacts
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-    - name: Run tests on binding
-      run: |
-        set -ex
-        cd '${{ github.workspace }}'
-        export LIBDDWAF_INSTALL_PREFIX='${{ env.tempdir }}/out'
-        ./gradlew --build-cache check --info -PuseReleaseBinaries
-      shell: bash
-    - name: Save Artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        path: ${{ env.tempdir }}/packages
-        name: libsqreen_jni_${{ env.artifactsuff }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          clean: true
+      - name: Build libddwaf
+        run: ci/build build-libddwaf --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
+      - name: Build JNI bindings
+        run: ci/build build-bindings --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
+      - name: Run tests
+        run: ci/build run-tests --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
+      - name: Save Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: build/native_libs
+          name: jni_${{ env.artifactsuff }}
+
   Native_binaries_Stage_macos_aarch64:
     name: MacOS aarch64
     runs-on: macOS-12
     env:
-      generator: Unix Makefiles
-      shlib_prefix: lib
-      shlib_ext: dylib
-      debug_ext: dylib.dwarf
+      os: macos
+      arch: aarch64
+      libc: ""
       artifactsuff: macos-aarch64
-      libdir: macos/aarch64
     steps:
-      - uses: actions/checkout@v4
-        name: Checkout
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           clean: true
-      - name: Create Build Directory for libddwaf
-        run: cmake -E make_directory "${{ env.tempdir }}/buildPW"
-      - name: Create Build Directory for JNI binding
-        run: cmake -E make_directory "${{ env.tempdir }}/buildAG"
-      - name: Create Packages Directory
-        run: cmake -E make_directory ${{ env.tempdir }}/packages
-      - name: Generate Build Scripts for libddwaf
-        run: |
-          cmake -DCMAKE_OSX_ARCHITECTURES=arm64 \
-            -DCMAKE_BUILD_TYPE=${{ env.buildType }} \
-            -DLIBDDWAF_BUILD_STATIC=0 \
-            -DCMAKE_C_FLAGS="-mmacosx-version-min=11.6 -fno-omit-frame-pointer" \
-            -DCMAKE_CXX_FLAGS="-mmacosx-version-min=11.6 -fno-omit-frame-pointer" \
-            -DCMAKE_INSTALL_PREFIX='${{ env.tempdir }}/out' \
-            -G '${{ env.generator }}' '${{ github.workspace }}/libddwaf'
-        working-directory: ${{ env.tempdir }}/buildPW
-      - name: Build Binaries for libddwaf
-        run: cmake --build .
-        working-directory: ${{ env.tempdir }}/buildPW
-      - name: Install Binaries for libddwaf
-        run: cmake --build . --target install
-        working-directory: ${{ env.tempdir }}/buildPW
-      - name: Generate Build Scripts for JNI binding
-        run: |
-          cmake -DCMAKE_OSX_ARCHITECTURES=arm64 \
-            -DCMAKE_BUILD_TYPE=${{ env.buildType }} \
-            -DCMAKE_PREFIX_PATH='${{ env.tempdir }}/out/share/cmake/libddwaf/' \
-            -DCMAKE_C_FLAGS="-mmacosx-version-min=11.6 -fno-omit-frame-pointer" \
-            -G "${{ env.generator }}" ${{ github.workspace }}
-        working-directory: ${{ env.tempdir }}/buildAG
-      - name: Build Binaries for JNI Binding
-        run: cmake --build .
-        working-directory: ${{ env.tempdir }}/buildAG
-      - name: Copy libddwaf binaries to packages
-        run: |
-          cmake -E copy ${{ env.shlib_prefix }}ddwaf.${{ env.shlib_ext }} \
-            ${{ env.shlib_prefix }}ddwaf.${{ env.debug_ext }} \
-            ${{ env.tempdir }}/packages
-        working-directory: ${{ env.tempdir }}/buildPW
-      - name: Copy libddwaf binding binaries to native_libs (testing)
-        run: |
-          cmake -E copy ${{ env.shlib_prefix }}ddwaf.${{ env.shlib_ext }} \
-            ${{ env.shlib_prefix }}ddwaf.${{ env.debug_ext }} \
-            ${{ github.workspace }}/native_libs/${{ env.libdir }}
-        working-directory: ${{ env.tempdir }}/buildPW
-      - name: Copy JNI binding binaries to packages
-        run: |
-          cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} \
-            ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} \
-            ${{ env.tempdir }}/packages
-        working-directory: ${{ env.tempdir }}/buildAG
-      - name: Copy JNI binding binaries to native_libs (testing)
-        run: |
-          cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} \
-            ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} \
-            ${{ github.workspace }}/native_libs/${{ env.libdir }}
-        working-directory: ${{ env.tempdir }}/buildAG
-      - name: Cache Gradle artifacts
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-#      - name: Run tests on binding
-#        run: |
-#          set -ex
-#          cd '${{ github.workspace }}'
-#          export LIBDDWAF_INSTALL_PREFIX='${{ env.tempdir }}/out'
-#          ./gradlew --build-cache check --info -PuseReleaseBinaries
-#        shell: bash
+      - name: Build libddwaf
+        run: ci/build build-libddwaf --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
+      - name: Build JNI bindings
+        run: ci/build build-bindings --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
+      # No arm64 tests for now (will do with macos-13)
+      #- name: Run tests
+      #  run: ci/build run-tests --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.tempdir }}/packages
-          name: libsqreen_jni_${{ env.artifactsuff }}
+          path: build/native_libs
+          name: jni_${{ env.artifactsuff }}
 
   Native_binaries_Stage_windows_x86_64:
     name: Windows x86_64
@@ -244,15 +109,13 @@ jobs:
       run:
         shell: cmd
     env:
-      generator: NMake Makefiles
-      shlib_prefix: 
-      shlib_ext: dll
-      debug_ext: pdb
+      os: windows
+      arch: x86_64
+      libc: ""
       artifactsuff: win-x86_64
-      libdir: windows/x86_64
     steps:
-      - uses: actions/checkout@v4
-        name: Checkout
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           clean: true
@@ -261,58 +124,24 @@ jobs:
         with:
           toolset: 14.29
           arch: amd64
-      - name: Create Build Directory for libddwaf
-        run: cmake -E make_directory "${{ env.tempdir }}/buildPW"
-      - name: Create Build Directory for JNI binding
-        run: cmake -E make_directory "${{ env.tempdir }}/buildAG"
-      - name: Create Packages Directory
-        run: cmake -E make_directory ${{ env.tempdir }}/packages
-      - name: Generate Build Scripts for libddwaf
-        run: |
-          cmake -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DLIBDDWAF_BUILD_SHARED=0 -DCMAKE_INSTALL_PREFIX="${{ env.tempdir }}/out" -G "${{ env.generator }}" "${{ github.workspace }}/libddwaf"
-        working-directory: ${{ env.tempdir }}/buildPW
-      - name: Build Binaries for libddwaf
-        run: cmake --build . --target libddwaf_static
-        working-directory: ${{ env.tempdir }}/buildPW
-      - name: Install Binaries for libddwaf
+      - name: Build libddwaf (cmake)
+        #run: ci/build build-libddwaf --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
+        run: cmake -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DLIBDDWAF_BUILD_SHARED=0 -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/libddwaf/Debug/out/usr/local" -G "NMake Makefiles" "${{ github.workspace }}/libddwaf"
+      - name: Build libddwaf (make)
+        run: cmake --build . --verbose
+      - name: Build libddwaf (make install)
         run: cmake --build . --target install
-        working-directory: ${{ env.tempdir }}/buildPW
-      - name: Generate Build Scripts for JNI binding
-        run: |
-          cmake -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DCMAKE_PREFIX_PATH="${{ env.tempdir }}/out/share/cmake/libddwaf/" -G "${{ env.generator }}" "${{ github.workspace }}"
-        working-directory: ${{ env.tempdir }}/buildAG
-      - name: Build Binaries for JNI Binding
-        run: cmake --build .
-        working-directory: ${{ env.tempdir }}/buildAG
-      - name: Copy JNI binding binaries to packages
-        run: cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} ${{ env.tempdir }}\packages
-        shell: cmd
-        working-directory: ${{ env.tempdir }}/buildAG
-      - name: Copy JNI binding binaries to native_libs (testing)
-        run: cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} ${{ github.workspace }}\native_libs\${{ env.libdir }}
-        shell: cmd
-        working-directory: ${{ env.tempdir }}/buildAG
-      - name: Cache Gradle artifacts
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-      - name: Run tests on binding
-        run: |
-          set -ex
-          cd '${{ github.workspace }}'
-          export LIBDDWAF_INSTALL_PREFIX='${{ env.tempdir }}/out'
-          ./gradlew --build-cache check --info -PuseReleaseBinaries
+      - name: Build JNI bindings
+        run: ci/build build-bindings --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
+        shell: bash
+      - name: Run tests
+        run: ci/build run-tests --os '${{ env.os }}' --arch '${{ env.arch }}' --libc '${{ env.libc }}'
         shell: bash
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.tempdir }}/packages
-          name: libsqreen_jni_${{ env.artifactsuff }}
+          path: build/native_libs
+          name: jni_${{ env.artifactsuff }}
 
   Native_binaries_Stage_libddwaf_linux_x86_64:
     name: Linux x86_64 (semi-static libddwaf.so)
@@ -321,7 +150,7 @@ jobs:
       dockerfile: ci/alpine-libc++-static/x86_64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
         with:
           submodules: recursive
           clean: true
@@ -329,12 +158,10 @@ jobs:
         id: buildx
         with:
           install: true
-      - name: Create packages directory
-        run: mkdir -p ${{ env.tempdir }}/packages
       - name: Build semi-statically compiled dynamic library
         run: docker buildx build -f ${{ env.dockerfile  }}/Dockerfile --progress=plain -o ${{ env.tempdir }}/packages .
       - name: Save Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v2
         with:
           path: ${{ env.tempdir }}/packages
           name: libddwaf_linux-x86_64
@@ -346,7 +173,7 @@ jobs:
       dockerfile: ci/alpine-libc++-static/aarch64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
         with:
           submodules: recursive
           clean: true
@@ -361,7 +188,7 @@ jobs:
       - name: Build semi-statically compiled dynamic library
         run: docker buildx build -f ${{ env.dockerfile  }}/Dockerfile --platform linux/arm64 --progress=plain -o ${{ env.tempdir }}/packages .
       - name: Save Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v2
         with:
           path: ${{ env.tempdir }}/packages
           name: libddwaf_linux-aarch64
@@ -372,49 +199,31 @@ jobs:
     needs:
       - Native_binaries_Stage_libddwaf_linux_x86_64
     env:
-      dockerfile: ci/manylinux/x86_64
+      os: linux
+      arch: x86_64
+      libc: glibc
       artifactsuff: linux_glibc-x86_64
-      libdir: linux/x86_64/glibc
-      artifactsDirectory: ${{ github.workspace }}/artifacts
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           clean: true
-      - name: Create artifacts directory
-        run: mkdir -p ${{ env.artifactsDirectory }}
       - name: Download libddwaf artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v2
         with:
           name: libddwaf_linux-x86_64
-          path: ${{ env.artifactsDirectory }}
-      - name: Build docker linux image
-        run: docker build ${{ env.dockerfile  }} -t linux_cmake
-      - name: Build and test JNI binding
-        run: |
-          docker run --name pwaf_java_build -v $(pwd):${{ github.workspace }} linux_cmake bash -e -c 'export VERBOSE=1;
-            export LIBDDWAF_INSTALL_PREFIX=/;
-            tar --strip-components=1 -xf ${{ env.artifactsDirectory }}/libddwaf-x86_64.tar.gz -C /usr/local/ &&
-            mkdir buildAG && cd buildAG &&
-            cmake ${{ github.workspace }} -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DCMAKE_C_FLAGS="-fno-omit-frame-pointer" &&
-            make -j &&
-            cp -v /usr/local/lib/libddwaf.so ${{ github.workspace }}/native_libs/linux/x86_64 &&
-            cp -v *.so ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
-            cd ${{ github.workspace }} &&
-            ./gradlew check --info -PuseReleaseBinaries'
-        shell: bash
-      - name: Copy binaries and debug symbols
-        run: |
-          sudo chown -R $(whoami) "${{ env.tempdir }}"
-          mkdir ${{ env.tempdir }}/packages
-          cd ${{ env.tempdir }}/packages
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so .
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so.debug .
+          path: libddwaf/Debug/out/usr/local/
+      - name: Build docker image
+        run: ci/build build-docker-image --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
+      - name: Build JNI bindings
+        run: ci/build build-bindings-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
+      - name: Run tests
+        run: ci/build run-tests-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.tempdir }}/packages
+          path: build/native_libs
           name: jni_${{ env.artifactsuff }}
 
   Native_binaries_Stage_linux_x86_64_musl:
@@ -423,49 +232,31 @@ jobs:
     needs:
       - Native_binaries_Stage_libddwaf_linux_x86_64
     env:
-      dockerfile: ci/alpine
+      os: linux
+      arch: x86_64
+      libc: musl
       artifactsuff: linux_musl-x86_64
-      libdir: linux/x86_64/musl
-      artifactsDirectory: ${{ github.workspace }}/artifacts
-    steps: # identical to glibc
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           clean: true
-      - name: Create artifacts directory
-        run: mkdir -p ${{ env.artifactsDirectory }}
       - name: Download libddwaf artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v2
         with:
           name: libddwaf_linux-x86_64
-          path: ${{ env.artifactsDirectory }}
-      - name: Build docker linux image
-        run: docker build ${{ env.dockerfile  }} -t linux_cmake
-      - name: Build and test with release binaries
-        run: |
-          docker run --name pwaf_java_build -v $(pwd):${{ github.workspace }} linux_cmake bash -e -c 'export VERBOSE=1;
-            export LIBDDWAF_INSTALL_PREFIX=/;
-            tar --strip-components=1 -xvf ${{ env.artifactsDirectory }}/libddwaf-x86_64.tar.gz -C /usr/local/ &&
-            mkdir buildAG && cd buildAG &&
-            cmake ${{ github.workspace }} -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DCMAKE_C_FLAGS="-fno-omit-frame-pointer" &&
-            make -j &&
-            cp -v /usr/local/lib/libddwaf.so ${{ github.workspace }}/native_libs/linux/x86_64 &&
-            cp -v *.so ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
-            cd ${{ github.workspace }} &&
-            ./gradlew check --info -PuseReleaseBinaries'
-        shell: bash
-      - name: Copy binaries and debug symbols
-        run: |
-          sudo chown -R $(whoami) ${{ env.tempdir }}
-          mkdir ${{ env.tempdir }}/packages
-          cd ${{ env.tempdir }}/packages
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so .
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so.debug .
+          path: libddwaf/Debug/out/usr/local/
+      - name: Build docker image
+        run: ci/build build-docker-image --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
+      - name: Build JNI bindings
+        run: ci/build build-bindings-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
+      - name: Run tests
+        run: ci/build run-tests-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.tempdir }}/packages
+          path: build/native_libs
           name: jni_${{ env.artifactsuff }}
 
   Native_binaries_Stage_linux_aarch64_glibc:
@@ -474,55 +265,34 @@ jobs:
     needs:
       - Native_binaries_Stage_libddwaf_linux_aarch64
     env:
-      dockerfile: ci/manylinux/aarch64
+      os: linux
+      arch: aarch64
+      libc: glibc
       artifactsuff: linux_glibc-aarch64
-      libdir: linux/aarch64/glibc
-      artifactsDirectory: ${{ github.workspace }}/artifacts
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           clean: true
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Create artifacts directory
-        run: mkdir -p ${{ env.artifactsDirectory }}
       - name: Download libddwaf artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v2
         with:
           name: libddwaf_linux-aarch64
-          path: ${{ env.artifactsDirectory }}
-      - name: Build docker linux image
-        run: docker build --platform linux/arm64 ${{ env.dockerfile  }} -t linux_cmake_aarch64
-      - name: Build and test JNI binding
-        run: |
-          docker run --platform arm64 --name pwaf_java_build -v $(pwd):${{ github.workspace }} linux_cmake_aarch64 bash -e -c 'export VERBOSE=1;
-            export LIBDDWAF_INSTALL_PREFIX=/;
-            git config --global --add safe.directory /home/runner/work/libddwaf-java/libddwaf-java &&
-            tar --strip-components=1 -xf ${{ env.artifactsDirectory }}/libddwaf-aarch64.tar.gz -C /usr/local/ &&
-            mkdir buildAG && cd buildAG &&
-            cmake ${{ github.workspace }} -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DCMAKE_C_FLAGS="-fno-omit-frame-pointer" &&
-            make -j &&
-            cp -v /usr/local/lib/libddwaf.so ${{ github.workspace }}/native_libs/linux/aarch64 &&
-            cp -v *.so /usr/local/lib/libddwaf.so ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
-            cd ${{ github.workspace }} &&
-            ./gradlew check --info -PuseReleaseBinaries'
-        shell: bash
-      - name: Copy binaries and debug symbols
-        run: |
-          sudo chown -R $(whoami) "${{ env.tempdir }}"
-          mkdir ${{ env.tempdir }}/packages
-          cd ${{ env.tempdir }}/packages
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so .
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so.debug .
+          path: libddwaf/Debug/out/usr/local/
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Build docker image
+        run: ci/build build-docker-image --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
+      - name: Build JNI bindings
+        run: ci/build build-bindings-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
+      - name: Run tests
+        run: ci/build run-tests-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.tempdir }}/packages
+          path: build/native_libs
           name: jni_${{ env.artifactsuff }}
-      - name: Cleanup
-        run: sudo git clean -ffdx
 
   Native_binaries_Stage_linux_aarch64_musl:
     name: Linux aarch64 (musl)
@@ -530,54 +300,34 @@ jobs:
     needs:
       - Native_binaries_Stage_libddwaf_linux_aarch64
     env:
-      dockerfile: ci/alpine
+      os: linux
+      arch: aarch64
+      libc: musl
       artifactsuff: linux_musl-aarch64
-      libdir: linux/aarch64/musl
-      artifactsDirectory: ${{ github.workspace }}/artifacts
-    steps: # identical to glibc
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           clean: true
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Create artifacts directory
-        run: mkdir -p ${{ env.artifactsDirectory }}
       - name: Download libddwaf artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v2
         with:
           name: libddwaf_linux-aarch64
-          path: ${{ env.artifactsDirectory }}
-      - name: Build docker linux image
-        run: docker build --platform linux/arm64 ${{ env.dockerfile  }} -t linux_cmake
-      - name: Build and test with release binaries
-        run: |
-          docker run --platform linux/arm64 --name pwaf_java_build -v $(pwd):${{ github.workspace }} linux_cmake bash -e -c 'export VERBOSE=1;
-            export LIBDDWAF_INSTALL_PREFIX=/;
-            tar --strip-components=1 -xvf ${{ env.artifactsDirectory }}/libddwaf-aarch64.tar.gz -C /usr/local/ &&
-            mkdir buildAG && cd buildAG &&
-            cmake ${{ github.workspace }} -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DCMAKE_C_FLAGS="-fno-omit-frame-pointer" &&
-            make -j &&
-            cp -v /usr/local/lib/libddwaf.so ${{ github.workspace }}/native_libs/linux/aarch64 &&
-            cp -v *.so ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
-            cd ${{ github.workspace }} &&
-            ./gradlew check --info -PuseReleaseBinaries'
-        shell: bash
-      - name: Copy binaries and debug symbols
-        run: |
-          sudo chown -R $(whoami) ${{ env.tempdir }}
-          mkdir ${{ env.tempdir }}/packages
-          cd ${{ env.tempdir }}/packages
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so .
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so.debug .
+          path: libddwaf/Debug/out/usr/local/
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Build docker image
+        run: ci/build build-docker-image --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
+      - name: Build JNI bindings
+        run: ci/build build-bindings-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
+      - name: Run tests
+        run: ci/build run-tests-in-docker --os ${{ env.os }} --arch ${{ env.arch }} --libc ${{ env.libc }}
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.tempdir }}/packages
+          path: build/native_libs
           name: jni_${{ env.artifactsuff }}
-      - name: Cleanup
-        run: sudo git clean -ffdx
 
   Native_binaries_Stage_asan:
     name: ASAN/static analyzer on Linux
@@ -587,12 +337,12 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
+        clean: true
     - name: Install GCC and clang
       run: |
         sudo apt-get update
         sudo apt-get install -y libc++-dev libc++abi-dev libc++abi1 libstdc++-12-dev gcc g++ \
           clang clang-tools ruby
-      shell: bash
     - name: Build libddwaf
       run: |
         set -ex
@@ -608,33 +358,19 @@ jobs:
           -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address -fsanitize=undefined -fsanitize=leak"
         VERBOSE=1 make -j
         DESTDIR=out make install
-      shell: bash
     - name: Run static analyzer
       run: |
         ci/static_analysis
-      shell: bash
-    - name: Cache Gradle artifacts
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
     - name: Run Binding Tests
       run: |
         set -ex
-        VERBOSE=1 ./gradlew --build-cache buildNativeLibDebug -PwithASAN --info
+        VERBOSE=1 ./gradlew --build-cache buildNativeLib -PwithASAN -PlibddwafPath=libddwaf/Debug/out/usr/local --info
         ASAN_OPTIONS="verbosity=1 handle_segv=0 fast_unwind_on_malloc=0 detect_leaks=0" \
           LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.8 \
-          ./gradlew --build-cache -x buildNativeLibDebug --info test
-      shell: bash
+          ./gradlew --build-cache -x buildNativeLib --info test
   Jar_File_Stage_build_jar:
     name: Build & Publish
     runs-on: ubuntu-20.04
-    env:
-      artifactsDirectory: ${{ github.workspace }}/artifacts
     needs:
       - Native_binaries_Stage_macos_x86_64
       - Native_binaries_Stage_macos_aarch64
@@ -644,8 +380,6 @@ jobs:
       - Native_binaries_Stage_linux_aarch64_glibc
       - Native_binaries_Stage_linux_aarch64_musl
       - Native_binaries_Stage_asan
-      - Native_binaries_Stage_libddwaf_linux_x86_64
-      - Native_binaries_Stage_libddwaf_linux_aarch64
     steps:
     - name: Setup JDK 1.8
       uses: actions/setup-java@v1
@@ -656,76 +390,43 @@ jobs:
       with:
         submodules: recursive
         clean: true
-    - name: Download libsqreen_jni_win-x86_64
+    - name: Download jni_win-x86_64
       uses: actions/download-artifact@v4
       with:
-        name: libsqreen_jni_win-x86_64
-        path: ${{ env.artifactsDirectory }}/libsqreen_jni_win-x86_64
-    - name: Download libddwaf_linux-x86_64
-      uses: actions/download-artifact@v4
-      with:
-        name: libddwaf_linux-x86_64
-        path: ${{ env.artifactsDirectory }}/libsqreen_linux-x86_64
-    - name: Download libddwaf_linux-aarch64
-      uses: actions/download-artifact@v4
-      with:
-        name: libddwaf_linux-aarch64
-        path: ${{ env.artifactsDirectory }}/libsqreen_linux-aarch64
+        name: jni_win-x86_64
+        path: build/native_libs
     - name: Download jni_linux_glibc-x86_64
       uses: actions/download-artifact@v4
       with:
         name: jni_linux_glibc-x86_64
-        path: ${{ env.artifactsDirectory }}/jni_linux_glibc-x86_64
+        path: build/native_libs
     - name: Download jni_linux_glibc-aarch64
       uses: actions/download-artifact@v4
       with:
         name: jni_linux_glibc-aarch64
-        path: ${{ env.artifactsDirectory }}/jni_linux_glibc-aarch64
+        path: build/native_libs
     - name: Download jni_linux_musl-x86_64
       uses: actions/download-artifact@v4
       with:
         name: jni_linux_musl-x86_64
-        path: ${{ env.artifactsDirectory }}/jni_linux_musl-x86_64
+        path: build/native_libs
     - name: Download jni_linux_musl-aarch64
       uses: actions/download-artifact@v4
       with:
         name: jni_linux_musl-aarch64
-        path: ${{ env.artifactsDirectory }}/jni_linux_musl-aarch64
-    - name: Download libsqreen_jni_macos-x86_64
+        path: build/native_libs
+    - name: Download jni_macos-x86_64
       uses: actions/download-artifact@v4
       with:
-        name: libsqreen_jni_macos-x86_64
-        path: ${{ env.artifactsDirectory }}/libsqreen_jni_macos-x86_64
-    - name: Download libsqreen_jni_macos_aarch64
+        name: jni_macos-x86_64
+        path: build/native_libs
+    - name: Download jni_macos_aarch64
       uses: actions/download-artifact@v4
       with:
-        name: libsqreen_jni_macos-aarch64
-        path: ${{ env.artifactsDirectory }}/libsqreen_jni_macos-aarch64
+        name: jni_macos-aarch64
+        path: build/native_libs
     - run: find .
-      working-directory: ${{ env.artifactsDirectory }}
-    - name: Copy the artifacts to the correct directories
-      run: |
-        set -ex
-        cp ${{ env.artifactsDirectory }}/libsqreen_jni_win-x86_64/* native_libs/windows/x86_64/
-        LIBDDWAF_TAR="${{ env.artifactsDirectory }}/libsqreen_linux-x86_64/libddwaf-x86_64.tar.gz"
-        tar -xvf "$LIBDDWAF_TAR" -C native_libs/linux/x86_64/ --strip-components=2 `tar -tf "$LIBDDWAF_TAR" | grep '\.so$'`
-        tar -xvf "$LIBDDWAF_TAR" -C native_libs/linux/x86_64/ --strip-components=4 `tar -tf "$LIBDDWAF_TAR" | grep '\.debug$'`
-        mv native_libs/linux/x86_64/*.debug native_libs/linux/x86_64/libddwaf.so.debug
-        
-        LIBDDWAF_TAR="${{ env.artifactsDirectory }}/libsqreen_linux-aarch64/libddwaf-aarch64.tar.gz"
-        tar -xvf "$LIBDDWAF_TAR" -C native_libs/linux/aarch64/ --strip-components=2 `tar -tf "$LIBDDWAF_TAR" | grep '\.so$'`
-        tar -xvf "$LIBDDWAF_TAR" -C native_libs/linux/aarch64/ --strip-components=4 `tar -tf "$LIBDDWAF_TAR" | grep '\.debug$'`
-        mv native_libs/linux/aarch64/*.debug native_libs/linux/aarch64/libddwaf.so.debug
-        
-        cp ${{ env.artifactsDirectory }}/jni_linux_glibc-x86_64/* native_libs/linux/x86_64/glibc/
-        cp ${{ env.artifactsDirectory }}/jni_linux_musl-x86_64/* native_libs/linux/x86_64/musl/
-        
-        cp ${{ env.artifactsDirectory }}/jni_linux_glibc-aarch64/* native_libs/linux/aarch64/glibc/
-        cp ${{ env.artifactsDirectory }}/jni_linux_musl-aarch64/* native_libs/linux/aarch64/musl/
-        
-        cp ${{ env.artifactsDirectory }}/libsqreen_jni_macos-x86_64/* native_libs/macos/x86_64/
-        cp ${{ env.artifactsDirectory }}/libsqreen_jni_macos-aarch64/* native_libs/macos/aarch64/
-      shell: bash
+      working-directory: build/native_libs
     - name: Cache Gradle artifacts
       uses: actions/cache@v2
       with:
@@ -743,7 +444,6 @@ jobs:
         mkdir -p "${{ env.tempdir }}/packages"
         cp ${{ github.workspace }}/build/libs/libsqreen-*.jar "${{ env.tempdir }}/packages"
         cp ${{ github.workspace }}/build/distributions/libsqreen-*-dbgsym.zip "${{ env.tempdir }}/packages"
-      shell: bash
     - name: Publish artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -38,73 +38,71 @@ targetCompatibility = 1.8
 
 def WINDOWS = org.gradle.internal.os.OperatingSystem.current().windows
 def MACOS = org.gradle.internal.os.OperatingSystem.current().macOsX
+def IS_RELEASE =  project.hasProperty("release")
+def cmakeBuildDir = IS_RELEASE? "$buildDir/RelWithDebInfo" : "$buildDir/Debug"
 
-task cmakeNativeLibDebug(type: Exec) {
+task cmakeNativeLib(type: Exec) {
     outputs.upToDateWhen { false }
-    description = 'Runs cmake in a debug configuration'
-
-    def pwafConfDir = project.hasProperty('libddwafConfig') ?
-            project.libddwafConfig :
-            "$projectDir/libddwaf/Debug/out/usr/local/share/cmake/libddwaf"
+    description = 'Runs cmake'
 
     doFirst {
-        def f = file("$pwafConfDir/libddwaf-config-debug.cmake")
-        if (!f.exists()) {
-            logger.warn("The file $f does not exist. libddwaf debug must be installed globally. " +
-                    "Run with -PlibddwafConfig=/path/to/dir/of/libddwaf-config-debug.cmake to override")
-        }
-
-        file("$buildDir/Debug").mkdirs()
+        file(cmakeBuildDir).mkdirs()
     }
 
     inputs.file 'CMakeLists.txt'
-    outputs.dir "$buildDir/Debug/"
+    outputs.dir cmakeBuildDir
+    workingDir cmakeBuildDir
 
     logging.captureStandardError  LogLevel.ERROR
     logging.captureStandardOutput LogLevel.INFO
 
-    def cmakeOpts
+    def cmakeOpts = []
     if (project.hasProperty('withASAN')) {
-        cmakeOpts = [
+        cmakeOpts += [
             '-DCMAKE_C_COMPILER=clang',
             '-DCMAKE_CXX_COMPILER=clang++',
             '-DCMAKE_C_FLAGS=-fsanitize=address -fsanitize=undefined -fsanitize=leak --coverage',
             '-DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=address -fsanitize=undefined -fsanitize=leak -lubsan -lasan --coverage',
         ]
-        if (WINDOWS) {
-            logger.warn('Address sanitizer not supported on Windows')
-        }
-    } else {
-        cmakeOpts = [
-            '-DCMAKE_C_FLAGS=--coverage',
-            '-DCMAKE_SHARED_LINKER_FLAGS=--coverage',
-        ]
+        assert !WINDOWS, 'Address sanitizer not supported on Windows'
     }
+
     if (project.hasProperty('macArch')) {
         cmakeOpts += ["-DCMAKE_OSX_ARCHITECTURES=${project.macArch}"]
     }
 
-    if (WINDOWS) {
-        commandLine 'cmake', "-DCMAKE_PREFIX_PATH=$pwafConfDir", '-S', projectDir, '-B', '.'
+    if (IS_RELEASE) {
+        cmakeOpts += ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"]
     } else {
-        commandLine('cmake', '-DCMAKE_BUILD_TYPE=Debug', "-DCMAKE_PREFIX_PATH=$pwafConfDir",
-                             *cmakeOpts, '-S', projectDir, '-B', '.')
+        cmakeOpts += [
+                '-DCMAKE_BUILD_TYPE=Debug',
+                '-DCMAKE_C_FLAGS=--coverage',
+                '-DCMAKE_SHARED_LINKER_FLAGS=--coverage',
+        ]
     }
 
-    workingDir "$buildDir/Debug"
+    cmakeOpts += ['-DCMAKE_C_FLAGS="-fno-omit-frame-pointer"']
+
+    if (project.hasProperty('libddwafPath')) {
+        cmakeOpts += ["-DCMAKE_PREFIX_PATH=${project.libddwafPath}/share/cmake/libddwaf"]
+    } else {
+        cmakeOpts += ["-DCMAKE_PREFIX_PATH=${projectDir}/libddwaf/Debug/out/usr/local/share/cmake/libddwaf"]
+    }
+
+    commandLine('cmake', *cmakeOpts, '-S', projectDir, '-B', '.')
 }
 
-task buildNativeLibDebug(type: Exec) {
-    description = 'Builds the native JNI lib in a debug configuration'
+task buildNativeLib(type: Exec) {
+    description = 'Builds the native JNI lib'
     group = 'test'
 
     inputs.dir 'src/main/c'
     if (WINDOWS) {
-        outputs.file "$buildDir/Debug/Debug/libsqreen_jni.dll"
+        outputs.file "$cmakeBuildDir/Debug/libsqreen_jni.dll"
     } else if (MACOS) {
-        outputs.file "$buildDir/Debug/libsqreen_jni.dylib"
+        outputs.file "$cmakeBuildDir/libsqreen_jni.dylib"
     } else {
-        outputs.file "$buildDir/Debug/libsqreen_jni.so"
+        outputs.file "$cmakeBuildDir/libsqreen_jni.so"
     }
 
     logging.captureStandardError  LogLevel.ERROR
@@ -116,9 +114,9 @@ task buildNativeLibDebug(type: Exec) {
     } else {
         commandLine 'make', '-j', 'sqreen_jni', 'VERBOSE=1'
     }
-    workingDir "$buildDir/Debug"
+    workingDir cmakeBuildDir
 
-    dependsOn cmakeNativeLibDebug
+    dependsOn cmakeNativeLib
 }
 
 jacocoTestReport {
@@ -159,7 +157,7 @@ task sourcesJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.allSource
 }
 
-def nativeLibsDir = "$projectDir/native_libs"
+def nativeLibsDir = "$projectDir/build/native_libs"
 
 task checkForNativeLibs {
     doLast {
@@ -307,13 +305,13 @@ tasks.withType(Test).each {
     }
 
     it.jvmArgs += ['-Xcheck:jni', '-Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG', '-DPOWERWAF_EXIT_ON_LEAK=true']
-    if (project.hasProperty('useReleaseBinaries')) {
+    if (project.hasProperty('release')) {
         it.jvmArgs += ['-DuseReleaseBinaries=true']
         it.dependsOn copyNativeLibs
     } else {
-        def javaLibPath = WINDOWS ? "$buildDir\\Debug\\Debug" : "$buildDir/Debug"
+        def javaLibPath = WINDOWS ? "$cmakeBuildDir\\Debug" : "$cmakeBuildDir"
         it.jvmArgs += ["-Djava.library.path=$javaLibPath"]
-        it.dependsOn buildNativeLibDebug
+        it.dependsOn buildNativeLib
     }
 
     it.outputs.upToDateWhen { false }

--- a/ci/alpine-libc++-static/aarch64/Dockerfile
+++ b/ci/alpine-libc++-static/aarch64/Dockerfile
@@ -18,7 +18,7 @@ COPY . /AgentJavaNative
 #    Again, this is only needed for the cmake sanity checks.
 RUN mkdir /build && cd /build && cmake /AgentJavaNative/libddwaf \
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
-	-DCMAKE_INSTALL_PREFIX=/usr \
+	-DCMAKE_INSTALL_PREFIX=/usr/local \
 	-DCMAKE_C_COMPILER=clang \
 	-DCMAKE_CXX_COMPILER=clang++ \
 	-DCMAKE_CXX_FLAGS="-stdlib=libc++ -Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -fno-omit-frame-pointer" \
@@ -33,7 +33,8 @@ RUN mkdir /build && cd /build && cmake /AgentJavaNative/libddwaf \
 # -lm, -ldl, -lpthread need to be provided though
 RUN cd /build && VERBOSE=1 make -j
 RUN patchelf --remove-needed libc.musl-aarch64.so.1 /build/libddwaf.so
-RUN cd /build && make package && mv libddwaf-*.tar.gz libddwaf-aarch64.tar.gz
+RUN cd /build && mkdir -p out && DESTDIR=out make install
 
 FROM scratch
-COPY --from=libddwaf_build /build/libddwaf-aarch64.tar.gz /
+COPY --from=libddwaf_build /build/out/usr/local/ /
+

--- a/ci/alpine-libc++-static/x86_64/Dockerfile
+++ b/ci/alpine-libc++-static/x86_64/Dockerfile
@@ -18,7 +18,7 @@ COPY .. /AgentJavaNative
 #    Again, this is only needed for the cmake sanity checks.
 RUN mkdir /build && cd /build && cmake /AgentJavaNative/libddwaf \
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
-	-DCMAKE_INSTALL_PREFIX=/usr \
+	-DCMAKE_INSTALL_PREFIX=/usr/local \
 	-DCMAKE_C_COMPILER=clang \
 	-DCMAKE_CXX_COMPILER=clang++ \
 	-DCMAKE_CXX_FLAGS="-stdlib=libc++ -Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -fno-omit-frame-pointer" \
@@ -33,7 +33,7 @@ RUN mkdir /build && cd /build && cmake /AgentJavaNative/libddwaf \
 # -lm, -ldl, -lpthread need to be provided though
 RUN cd /build && VERBOSE=1 make -j
 RUN patchelf --remove-needed libc.musl-x86_64.so.1 /build/libddwaf.so
-RUN cd /build && make package && mv libddwaf-*.tar.gz libddwaf-x86_64.tar.gz
+RUN cd /build && mkdir -p out && DESTDIR=out make install
 
 FROM scratch
-COPY --from=libddwaf_build /build/libddwaf-x86_64.tar.gz /
+COPY --from=libddwaf_build /build/out/usr/local/ /

--- a/ci/build
+++ b/ci/build
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly OUTPUT_NATIVE_LIBS_DIR="build/native_libs"
+
+function cmd_build-docker-image() {
+    echo "Building docker image..."
+    docker build --platform "$OS/$ARCH" "$DOCKER_IMAGE" -t "libddwaf-build-$LIBC"
+}
+
+function cmd_build-libddwaf() {
+    echo "Building libddwaf..."
+    project_dir="$(pwd)/libddwaf"
+    if [[ ! -d libddwaf ]]; then
+        echo "libddwaf directory not found"
+        exit 1
+    fi
+    mkdir -p libddwaf/Debug
+    cd libddwaf/Debug
+
+    cmake_args=()
+
+    if [[ -n ${DEBUG:-} ]]; then
+        cmake_args+=("-DCMAKE_BUILD_TYPE=Debug")
+    else
+        cmake_args+=("-DCMAKE_BUILD_TYPE=RelWithDebInfo")
+    fi
+
+    c_flags=
+    if [[ $OS != windows ]]; then
+        c_flags="$c_flags -fno-omit-frame-pointer"
+    fi
+    if [[ $OS = macos ]]; then
+        c_flags="$c_flags -mmacosx-version-min=11.6"
+    fi
+    cmake_args+=("-DCMAKE_C_FLAGS=$c_flags")
+    cmake_args+=("-DCMAKE_CXX_FLAGS=$c_flags")
+
+    if [[ $OS = macos ]]; then
+        cmake_args+=("-DLIBDDWAF_BUILD_STATIC=0")
+    elif [[ $OS = windows ]]; then
+        cmake_args+=("-DLIBDDWAF_BUILD_SHARED=0")
+    fi
+
+    if [[ $OS = macos && $ARCH = aarch64 ]]; then
+        cmake_args+=("-DCMAKE_OSX_ARCHITECTURES=arm64")
+    fi
+
+    generator="Unix Makefiles"
+    if [[ $OS = windows ]]; then
+        generator="NMake Makefiles"
+    fi
+
+    cmake_args+=("-DCMAKE_INSTALL_PREFIX=$(pwd)/out/usr/local")
+
+    cmake \
+        "${cmake_args[@]}" \
+        -G "$generator" \
+        -S "$project_dir" \
+        -B .
+
+    cmake --build . --parallel "$(nproc)" --verbose
+
+    cmake --build . --target install
+}
+
+function cmd_build-bindings-in-docker() {
+    echo "Building JNI bindings in Docker..."
+    docker run \
+        --rm \
+        --platform "$OS/$ARCH" \
+        --user "$(id -u):$(id -g)" \
+        -v "$(pwd):/work" \
+        -w /work \
+        "libddwaf-build-$LIBC" \
+        ./ci/build build-bindings --os $OS --arch $ARCH --libc $LIBC
+}
+
+function cmd_build-bindings() {
+    echo "Building JNI bindings..."
+    project_dir="$(pwd)"
+    mkdir -p "$OUTPUT_NATIVE_LIBS_DIR"
+    mkdir -p /tmp/build
+    cd /tmp/build
+
+    cmake_args=("-DCMAKE_BUILD_TYPE=RelWithDebInfo")
+
+    c_flags=
+    if [[ $OS != windows ]]; then
+        c_flags="$c_flags -fno-omit-frame-pointer"
+    fi
+    if [[ $OS = macos ]]; then
+        c_flags="$c_flags -mmacosx-version-min=11.6"
+    fi
+    cmake_args+=("-DCMAKE_C_FLAGS=$c_flags")
+    cmake_args+=("-DCMAKE_CXX_FLAGS=$c_flags")
+
+    if [[ $OS = macos && $ARCH = aarch64 ]]; then
+        cmake_args+=("-DCMAKE_OSX_ARCHITECTURES=arm64")
+    fi
+
+    cmake_args+=("-DCMAKE_PREFIX_PATH=$project_dir/libddwaf/Debug/out/usr/local")
+
+    generator="Unix Makefiles"
+    if [[ $OS = windows ]]; then
+        generator="NMake Makefiles"
+    fi
+
+    cmake \
+        "${cmake_args[@]}" \
+        -G "$generator" \
+        -S "$project_dir" \
+        -B .
+
+    cmake --build . --parallel "$(nproc)" --verbose
+
+    if [[ $OS = linux ]]; then
+        output_path="$project_dir/$OUTPUT_NATIVE_LIBS_DIR/$OS/$ARCH/$LIBC"
+        mkdir -p "$output_path"
+        cp libsqreen_jni.so "$output_path/"
+        cp libsqreen_jni.so.debug "$output_path/"
+        cp "$project_dir/libddwaf/Debug/out/usr/local/lib/libddwaf.so" "$project_dir/$OUTPUT_NATIVE_LIBS_DIR/$OS/$ARCH/"
+    elif [[ $OS = macos ]]; then
+        output_path="$project_dir/$OUTPUT_NATIVE_LIBS_DIR/$OS/$ARCH"
+        mkdir -p "$output_path"
+        cp libsqreen_jni.dylib "$output_path/"
+        cp libsqreen_jni.dylib.dwarf "$output_path/"
+        cp "$project_dir/libddwaf/Debug/out/usr/local/lib/libddwaf.dylib" "$output_path/"
+        cp "$project_dir/libddwaf/Debug/libddwaf.dylib.dwarf" "$output_path/"
+    elif [[ $OS = windows ]]; then
+        output_path="$project_dir/$OUTPUT_NATIVE_LIBS_DIR/$OS/$ARCH"
+        mkdir -p "$output_path"
+        cp sqreen_jni.dll "$output_path/"
+        cp sqreen_jni.pdb "$output_path/"
+    else
+        echo "Invalid OS: $OS"
+        exit 1
+    fi
+}
+
+function cmd_run-tests-in-docker() {
+    echo "Run tests in Docker..."
+    docker run \
+        --rm \
+        --platform "$OS/$ARCH" \
+        --user "$(id -u):$(id -g)" \
+        -v "$(pwd):/work" \
+        -w /work \
+        "libddwaf-build-$LIBC" \
+        ./ci/build run-tests --os "$OS" --arch "$ARCH" --libc "${LIBC:-}"
+}
+
+function cmd_run-tests() {
+    echo "Run tests..."
+    ./gradlew check --info -Prelease
+}
+
+function get_libddwaf_version() {
+    grep -E 'set\(LIBDDWAF_VERSION\s+[0-9.a-zA-Z]+\)' deps/CMakeLists.txt | sed -e 's~.*\s\(.*\)).*~\1~g'
+}
+
+function cmd_get-libddwaf-version() {
+    get_libddwaf_version
+}
+
+COMMAND="$1"
+shift
+
+# Parse options
+DEBUG=
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --arch)
+            ARCH="$2"
+            shift 2
+            ;;
+        --os)
+            OS="$2"
+            shift 2
+            ;;
+        --libc)
+            LIBC="$2"
+            shift 2
+            ;;
+        --debug)
+            DEBUG=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+case "${OS:-}-${ARCH:-}-${LIBC:-}" in
+    linux-*-glibc)
+        DOCKER_IMAGE="ci/manylinux/$ARCH"
+        ;;
+    linux-*-musl)
+        DOCKER_IMAGE="ci/alpine"
+        ;;
+    *)
+        ;;
+esac
+
+# check if function cmd_$COMMAND exists, and then run it:
+if declare -F "cmd_$COMMAND" &> /dev/null; then
+    "cmd_$COMMAND" "$@"
+else
+    echo "Bad command: $COMMAND"
+    exit 1
+fi


### PR DESCRIPTION
## Changes

* Move most build logic from YAML to a bash script (`ci/build`) for easier code reuse in the workflow as well as easier local testing of CI actions.
* Use `build/native_libs` directly to store artifacts across builds. This reduces the need to move things back and forth in different steps.

## Future work
* Use bash for the Windows build. This currently leads to several problems since bash environment in GitHub Actions always preprends some environment variables, breaking the MSVC setup.