### PR TITLE
Fix macos libddwaf path in copy libs task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -262,8 +262,8 @@ task copyNativeLibs(type: Copy) {
                        ['linux/x86_64/musl/libsqreen_jni.so', 'linux/x86_64/libddwaf.so'],
                        ['linux/aarch64/glibc/libsqreen_jni.so', 'linux/aarch64/libddwaf.so'],
                        ['linux/aarch64/musl/libsqreen_jni.so', 'linux/aarch64/libddwaf.so'],
-                       ['macos/x86_64/libsqreen_jni.dylib', 'macos/x86_64/libddwaf.dylib.dwarf'],
-                       ['macos/aarch64/libsqreen_jni.dylib', 'macos/aarch64/libddwaf.dylib.dwarf'],
+                       ['macos/x86_64/libsqreen_jni.dylib', 'macos/x86_64/libddwaf.dylib'],
+                       ['macos/aarch64/libsqreen_jni.dylib', 'macos/aarch64/libddwaf.dylib'],
                        ['windows/x86_64/sqreen_jni.dll']]
 
     doFirst {


### PR DESCRIPTION
For every operating system, we check jni library and libddwaf, except for macOS, where we were checking for libddwaf debug symbols rather than the library itself.