### PR TITLE
Fixed segfault

### DIFF
--- a/src/main/c/jni/io_sqreen_powerwaf_Powerwaf.h
+++ b/src/main/c/jni/io_sqreen_powerwaf_Powerwaf.h
@@ -36,16 +36,16 @@ JNIEXPORT jobjectArray JNICALL Java_io_sqreen_powerwaf_Powerwaf_getKnownAddresse
  * Method:    runRules
  * Signature: (Lio/sqreen/powerwaf/PowerwafHandle;Ljava/nio/ByteBuffer;Lio/sqreen/powerwaf/Powerwaf$Limits;Lio/sqreen/powerwaf/PowerwafMetrics;)Lio/sqreen/powerwaf/Powerwaf$ResultWithData;
  */
-JNIEXPORT jobject JNICALL Java_io_sqreen_powerwaf_Powerwaf_runRules__Lio_sqreen_powerwaf_PowerwafHandle_2Ljava_nio_ByteBuffer_2Ljava_nio_ByteBuffer_2Lio_sqreen_powerwaf_Powerwaf_00024Limits_2Lio_sqreen_powerwaf_PowerwafMetrics_2
-  (JNIEnv *, jclass, jobject, jobject, jobject, jobject, jobject);
+JNIEXPORT jobject JNICALL Java_io_sqreen_powerwaf_Powerwaf_runRules__Lio_sqreen_powerwaf_PowerwafHandle_2Ljava_nio_ByteBuffer_2Lio_sqreen_powerwaf_Powerwaf_00024Limits_2Lio_sqreen_powerwaf_PowerwafMetrics_2
+  (JNIEnv *, jclass, jobject, jobject, jobject, jobject);
 
 /*
  * Class:     io_sqreen_powerwaf_Powerwaf
  * Method:    runRules
  * Signature: (Lio/sqreen/powerwaf/PowerwafHandle;Ljava/util/Map;Lio/sqreen/powerwaf/Powerwaf$Limits;Lio/sqreen/powerwaf/PowerwafMetrics;)Lio/sqreen/powerwaf/Powerwaf$ResultWithData;
  */
-JNIEXPORT jobject JNICALL Java_io_sqreen_powerwaf_Powerwaf_runRules__Lio_sqreen_powerwaf_PowerwafHandle_2Ljava_util_Map_2Ljava_util_Map_2Lio_sqreen_powerwaf_Powerwaf_00024Limits_2Lio_sqreen_powerwaf_PowerwafMetrics_2
-  (JNIEnv *, jclass, jobject, jobject, jobject, jobject, jobject);
+JNIEXPORT jobject JNICALL Java_io_sqreen_powerwaf_Powerwaf_runRules__Lio_sqreen_powerwaf_PowerwafHandle_2Ljava_util_Map_2Lio_sqreen_powerwaf_Powerwaf_00024Limits_2Lio_sqreen_powerwaf_PowerwafMetrics_2
+  (JNIEnv *, jclass, jobject, jobject, jobject, jobject);
 
 /*
  * Class:     io_sqreen_powerwaf_Powerwaf

--- a/src/main/c/powerwaf_jni.c
+++ b/src/main/c/powerwaf_jni.c
@@ -550,7 +550,7 @@ static jobject _run_rule_common(bool is_byte_buffer, JNIEnv *env, jclass clazz,
         _throw_pwaf_exception(env, DDWAF_ERR_INTERNAL);
         goto end;
     }
-    DDWAF_RET_CODE ret_code = ddwaf_run(ctx, &input, NULL, &ret, run_budget);
+    DDWAF_RET_CODE ret_code = ddwaf_run(ctx, NULL, &input, &ret, run_budget);
 
     if (log_level_enabled(DDWAF_LOG_DEBUG)) {
             JAVA_LOG(DDWAF_LOG_DEBUG,
@@ -594,6 +594,9 @@ freeRet:
 end:
     if (ctx) {
         ddwaf_context_destroy(ctx);
+    }
+    if (!is_byte_buffer) {
+        ddwaf_object_free(&input);
     }
 
     return result;

--- a/src/main/c/powerwaf_jni.c
+++ b/src/main/c/powerwaf_jni.c
@@ -529,6 +529,7 @@ static jobject _run_rule_common(bool is_byte_buffer, JNIEnv *env, jclass clazz,
             goto end;
         }
         if (!_get_time_checked(env, &conv_end)) {
+            ddwaf_object_free(&input);
             goto end;
         }
         rem_gen_budget_in_us = get_remaining_budget(start, conv_end, &limits);
@@ -538,6 +539,7 @@ static jobject _run_rule_common(bool is_byte_buffer, JNIEnv *env, jclass clazz,
                      "native conversion",
                      limits.general_budget_in_us);
             _throw_pwaf_timeout_exception(env);
+            ddwaf_object_free(&input);
             goto end;
         }
     }
@@ -594,9 +596,6 @@ freeRet:
 end:
     if (ctx) {
         ddwaf_context_destroy(ctx);
-    }
-    if (!is_byte_buffer) {
-        ddwaf_object_free(&input);
     }
 
     return result;
@@ -2318,6 +2317,6 @@ err:
 }
 
 static inline bool _has_derivative(const ddwaf_result *res) {
-    return res->derivatives.type == DDWAF_OBJ_MAP 
+    return res->derivatives.type == DDWAF_OBJ_MAP
     && res->derivatives.nbEntries > 0;
 }

--- a/src/main/java/io/sqreen/powerwaf/Powerwaf.java
+++ b/src/main/java/io/sqreen/powerwaf/Powerwaf.java
@@ -118,21 +118,18 @@ public final class Powerwaf {
      * See pw_runH.
      *
      * @param handle the PowerWAF rule handle
-     * @param persistentBuffer a persistent buffer whose first object should be top PWArgs
-     * @param ephemeralBuffer an ephemeral buffer whose first object should be top PWArgs
+     * @param firstPWArgsBuffer a buffer whose first object should be top PWArgs
      * @param limits the limits
      * @param metrics the metrics collector, or null
      * @return the resulting action (OK or MATCH) and associated details
      */
     static native ResultWithData runRules(PowerwafHandle handle,
-                                          ByteBuffer persistentBuffer,
-                                          ByteBuffer ephemeralBuffer,
+                                          ByteBuffer firstPWArgsBuffer,
                                           Limits limits,
                                           PowerwafMetrics metrics) throws AbstractPowerwafException;
 
     static native ResultWithData runRules(PowerwafHandle handle,
-                                          Map<String, Object> persistentData,
-                                          Map<String, Object> ephemeralData,
+                                          Map<String, Object> parameters,
                                           Limits limits,
                                           PowerwafMetrics metrics) throws AbstractPowerwafException;
 

--- a/src/main/java/io/sqreen/powerwaf/PowerwafContext.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafContext.java
@@ -110,8 +110,7 @@ public class PowerwafContext implements Closeable {
 
     public Powerwaf.ResultWithData runRules(Map<String, Object> parameters,
                                             Powerwaf.Limits limits,
-                                            PowerwafMetrics metrics,
-                                            boolean isEphemeral) throws AbstractPowerwafException {
+                                            PowerwafMetrics metrics) throws AbstractPowerwafException {
         this.readLock.lock();
         try {
             checkIfOnline();
@@ -139,13 +138,8 @@ public class PowerwafContext implements Closeable {
                                 this);
                         throw new TimeoutPowerwafException();
                     }
-                    if (isEphemeral) {
-                        res = Powerwaf.runRules(
-                                this.handle, null, lease.getFirstPWArgsByteBuffer(), newLimits, metrics);
-                    } else {
-                        res = Powerwaf.runRules(
-                                this.handle, lease.getFirstPWArgsByteBuffer(), null, newLimits, metrics);
-                    }
+                    res = Powerwaf.runRules(
+                            this.handle, lease.getFirstPWArgsByteBuffer(), newLimits, metrics);
                 } finally {
                     lease.close();
                     if (metrics != null) {
@@ -157,11 +151,7 @@ public class PowerwafContext implements Closeable {
                     }
                 }
             } else {
-                if (isEphemeral) {
-                    res = Powerwaf.runRules(this.handle, null, parameters, limits, metrics);
-                } else {
-                    res = Powerwaf.runRules(this.handle, parameters, null, limits, metrics);
-                }
+                res = Powerwaf.runRules(this.handle, parameters, limits, metrics);
             }
 
             LOGGER.debug("Rule of context {} ran successfully with return {}", this, res);
@@ -174,12 +164,6 @@ public class PowerwafContext implements Closeable {
         } finally {
             this.readLock.unlock();
         }
-    }
-
-    public Powerwaf.ResultWithData runRules(Map<String, Object> parameters,
-                                            Powerwaf.Limits limits,
-                                            PowerwafMetrics metrics) throws AbstractPowerwafException {
-        return runRules(parameters, limits, metrics, false);
     }
 
     public Additive openAdditive() {

--- a/src/main/java/io/sqreen/powerwaf/PowerwafContext.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafContext.java
@@ -13,7 +13,6 @@ import io.sqreen.powerwaf.exception.InvalidRuleSetException;
 import io.sqreen.powerwaf.exception.TimeoutPowerwafException;
 import io.sqreen.powerwaf.exception.UnclassifiedPowerwafException;
 import java.io.Closeable;
-import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -109,10 +108,10 @@ public class PowerwafContext implements Closeable {
         }
     }
 
-    public Powerwaf.ResultWithData runRules(Map<String, Object> persistentData,
-                                            Map<String, Object> ephemeralData,
+    public Powerwaf.ResultWithData runRules(Map<String, Object> parameters,
                                             Powerwaf.Limits limits,
-                                            PowerwafMetrics metrics) throws AbstractPowerwafException {
+                                            PowerwafMetrics metrics,
+                                            boolean isEphemeral) throws AbstractPowerwafException {
         this.readLock.lock();
         try {
             checkIfOnline();
@@ -124,23 +123,11 @@ public class PowerwafContext implements Closeable {
                 // serialization could be extracted out of the lock
                 ByteBufferSerializer serializer = new ByteBufferSerializer(limits);
                 long before = System.nanoTime();
-
-                ByteBuffer persistentBuffer = null;
-                if (persistentData != null) {
-                    try (ByteBufferSerializer.ArenaLease lease = serializer.serialize(persistentData)) {
-                        persistentBuffer = lease.getFirstPWArgsByteBuffer();
-                    } catch (Exception e) {
-                        throw new RuntimeException("Exception encoding parameters", e);
-                    }
-                }
-
-                ByteBuffer ephemeralBuffer = null;
-                if (ephemeralData != null) {
-                    try (ByteBufferSerializer.ArenaLease lease = serializer.serialize(ephemeralData)) {
-                        ephemeralBuffer = lease.getFirstPWArgsByteBuffer();
-                    } catch (Exception e) {
-                        throw new RuntimeException("Exception encoding parameters", e);
-                    }
+                ByteBufferSerializer.ArenaLease lease;
+                try {
+                    lease = serializer.serialize(parameters);
+                } catch (Exception e) {
+                    throw new RuntimeException("Exception encoding parameters", e);
                 }
                 try {
                     long elapsedNs = System.nanoTime() - before;
@@ -152,10 +139,15 @@ public class PowerwafContext implements Closeable {
                                 this);
                         throw new TimeoutPowerwafException();
                     }
-                    res = Powerwaf.runRules(
-                            this.handle, persistentBuffer, ephemeralBuffer, limits, metrics);
+                    if (isEphemeral) {
+                        res = Powerwaf.runRules(
+                                this.handle, null, lease.getFirstPWArgsByteBuffer(), newLimits, metrics);
+                    } else {
+                        res = Powerwaf.runRules(
+                                this.handle, lease.getFirstPWArgsByteBuffer(), null, newLimits, metrics);
+                    }
                 } finally {
-
+                    lease.close();
                     if (metrics != null) {
                         long after = System.nanoTime();
                         long totalTimeNs = after - before;
@@ -165,7 +157,11 @@ public class PowerwafContext implements Closeable {
                     }
                 }
             } else {
-                res = Powerwaf.runRules(this.handle, persistentData, ephemeralData, limits, metrics);
+                if (isEphemeral) {
+                    res = Powerwaf.runRules(this.handle, null, parameters, limits, metrics);
+                } else {
+                    res = Powerwaf.runRules(this.handle, parameters, null, limits, metrics);
+                }
             }
 
             LOGGER.debug("Rule of context {} ran successfully with return {}", this, res);
@@ -183,7 +179,7 @@ public class PowerwafContext implements Closeable {
     public Powerwaf.ResultWithData runRules(Map<String, Object> parameters,
                                             Powerwaf.Limits limits,
                                             PowerwafMetrics metrics) throws AbstractPowerwafException {
-        return runRules(parameters, null, limits, metrics);
+        return runRules(parameters, limits, metrics, false);
     }
 
     public Additive openAdditive() {

--- a/src/test/groovy/io/sqreen/powerwaf/AdditiveTest.groovy
+++ b/src/test/groovy/io/sqreen/powerwaf/AdditiveTest.groovy
@@ -161,7 +161,7 @@ class AdditiveTest implements ReactiveTrait {
             ctx = new PowerwafContext('test', null, ARACHNI_ATOM_V2_1)
             metrics = ctx.createMetrics()
 
-            ctx.runRules(null, null, limits, metrics)
+            ctx.runRules(null, limits, metrics)
         }
     }
 


### PR DESCRIPTION
# What Does This Do
Fixed memory management in WAF bindings to prevent early free memory.

# Motivation
A segmentation fault was identified, stemming from improper memory management. This was due to prematurely closing the lease, which inadvertently allowed the Garbage Collector to free memory still needed to WAF.