### PR TITLE
Simplify path handling during CI builds

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -97,25 +97,15 @@ jobs:
     - name: Build Binaries for JNI Binding
       run: cmake --build . --verbose
       working-directory: ${{ env.tempdir }}/buildAG
-    - name: Copy libddwaf binaries to packages
-      run: |
-        cmake -E copy ${{ env.shlib_prefix }}ddwaf.${{ env.shlib_ext }} \
-          ${{ env.shlib_prefix }}ddwaf.${{ env.debug_ext }} \
-          ${{ env.tempdir }}/packages
-      working-directory: ${{ env.tempdir }}/buildPW
-    - name: Copy libddwaf binding binaries to native_libs (testing)
+    - name: Create packages directory
+      run: mkdir -p ${{ github.workspace }}/native_libs/${{ env.libdir }}
+    - name: Copy libddwaf binaries to native_libs
       run: |
         cmake -E copy ${{ env.shlib_prefix }}ddwaf.${{ env.shlib_ext }} \
           ${{ env.shlib_prefix }}ddwaf.${{ env.debug_ext }} \
           ${{ github.workspace }}/native_libs/${{ env.libdir }}
       working-directory: ${{ env.tempdir }}/buildPW
-    - name: Copy JNI binding binaries to packages
-      run: |
-        cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} \
-          ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} \
-          ${{ env.tempdir }}/packages
-      working-directory: ${{ env.tempdir }}/buildAG
-    - name: Copy JNI binding binaries to native_libs (testing)
+    - name: Copy JNI binding binaries to native_libs
       run: |
         cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} \
           ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} \
@@ -140,7 +130,7 @@ jobs:
     - name: Save Artifacts
       uses: actions/upload-artifact@v4
       with:
-        path: ${{ env.tempdir }}/packages
+        path: native_libs
         name: libsqreen_jni_${{ env.artifactsuff }}
   Native_binaries_Stage_macos_aarch64:
     name: MacOS aarch64
@@ -191,25 +181,15 @@ jobs:
       - name: Build Binaries for JNI Binding
         run: cmake --build .
         working-directory: ${{ env.tempdir }}/buildAG
-      - name: Copy libddwaf binaries to packages
-        run: |
-          cmake -E copy ${{ env.shlib_prefix }}ddwaf.${{ env.shlib_ext }} \
-            ${{ env.shlib_prefix }}ddwaf.${{ env.debug_ext }} \
-            ${{ env.tempdir }}/packages
-        working-directory: ${{ env.tempdir }}/buildPW
-      - name: Copy libddwaf binding binaries to native_libs (testing)
+      - name: Create packages directory
+        run: mkdir -p ${{ github.workspace }}/native_libs/${{ env.libdir }}
+      - name: Copy libddwaf binaries to native_libs
         run: |
           cmake -E copy ${{ env.shlib_prefix }}ddwaf.${{ env.shlib_ext }} \
             ${{ env.shlib_prefix }}ddwaf.${{ env.debug_ext }} \
             ${{ github.workspace }}/native_libs/${{ env.libdir }}
         working-directory: ${{ env.tempdir }}/buildPW
-      - name: Copy JNI binding binaries to packages
-        run: |
-          cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} \
-            ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} \
-            ${{ env.tempdir }}/packages
-        working-directory: ${{ env.tempdir }}/buildAG
-      - name: Copy JNI binding binaries to native_libs (testing)
+      - name: Copy JNI binding binaries to native_libs
         run: |
           cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} \
             ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} \
@@ -234,7 +214,7 @@ jobs:
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.tempdir }}/packages
+          path: native_libs
           name: libsqreen_jni_${{ env.artifactsuff }}
 
   Native_binaries_Stage_windows_x86_64:
@@ -265,8 +245,6 @@ jobs:
         run: cmake -E make_directory "${{ env.tempdir }}/buildPW"
       - name: Create Build Directory for JNI binding
         run: cmake -E make_directory "${{ env.tempdir }}/buildAG"
-      - name: Create Packages Directory
-        run: cmake -E make_directory ${{ env.tempdir }}/packages
       - name: Generate Build Scripts for libddwaf
         run: |
           cmake -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DLIBDDWAF_BUILD_SHARED=0 -DCMAKE_INSTALL_PREFIX="${{ env.tempdir }}/out" -G "${{ env.generator }}" "${{ github.workspace }}/libddwaf"
@@ -284,12 +262,14 @@ jobs:
       - name: Build Binaries for JNI Binding
         run: cmake --build .
         working-directory: ${{ env.tempdir }}/buildAG
+      - name: Create packages directory
+        run: cmake -E make_directory ${{ github.workspace }}/native_libs/${{ env.libdir }}
       - name: Copy JNI binding binaries to packages
-        run: cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} ${{ env.tempdir }}\packages
+        run: cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} ${{ github.workspace }}\build\native_libs\${{ env.libdir }}
         shell: cmd
         working-directory: ${{ env.tempdir }}/buildAG
       - name: Copy JNI binding binaries to native_libs (testing)
-        run: cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} ${{ github.workspace }}\native_libs\${{ env.libdir }}
+        run: cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} ${{ github.workspace }}\build\native_libs\${{ env.libdir }}
         shell: cmd
         working-directory: ${{ env.tempdir }}/buildAG
       - name: Cache Gradle artifacts
@@ -311,7 +291,7 @@ jobs:
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.tempdir }}/packages
+          path: native_libs
           name: libsqreen_jni_${{ env.artifactsuff }}
 
   Native_binaries_Stage_libddwaf_linux_x86_64:
@@ -329,14 +309,12 @@ jobs:
         id: buildx
         with:
           install: true
-      - name: Create packages directory
-        run: mkdir -p ${{ env.tempdir }}/packages
       - name: Build semi-statically compiled dynamic library
-        run: docker buildx build -f ${{ env.dockerfile  }}/Dockerfile --progress=plain -o ${{ env.tempdir }}/packages .
+        run: docker buildx build -f ${{ env.dockerfile  }}/Dockerfile --progress=plain -o ${{ github.workspace }}/libddwaf/out .
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.tempdir }}/packages
+          path: libddwaf/out
           name: libddwaf_linux-x86_64
 
   Native_binaries_Stage_libddwaf_linux_aarch64:
@@ -356,14 +334,12 @@ jobs:
         id: buildx
         with:
           install: true
-      - name: Create packages directory
-        run: mkdir -p ${{ env.tempdir }}/packages
       - name: Build semi-statically compiled dynamic library
-        run: docker buildx build -f ${{ env.dockerfile  }}/Dockerfile --platform linux/arm64 --progress=plain -o ${{ env.tempdir }}/packages .
+        run: docker buildx build -f ${{ env.dockerfile  }}/Dockerfile --platform linux/arm64 --progress=plain -o ${{ github.workspace }}/libddwaf/out .
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.tempdir }}/packages
+          path: libddwaf/out
           name: libddwaf_linux-aarch64
 
   Native_binaries_Stage_linux_x86_64_glibc:
@@ -375,46 +351,39 @@ jobs:
       dockerfile: ci/manylinux/x86_64
       artifactsuff: linux_glibc-x86_64
       libdir: linux/x86_64/glibc
-      artifactsDirectory: ${{ github.workspace }}/artifacts
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           clean: true
-      - name: Create artifacts directory
-        run: mkdir -p ${{ env.artifactsDirectory }}
       - name: Download libddwaf artifact
         uses: actions/download-artifact@v4
         with:
           name: libddwaf_linux-x86_64
-          path: ${{ env.artifactsDirectory }}
+          path: libddwaf/out
       - name: Build docker linux image
         run: docker build ${{ env.dockerfile  }} -t linux_cmake
       - name: Build and test JNI binding
         run: |
-          docker run --name pwaf_java_build -v $(pwd):${{ github.workspace }} linux_cmake bash -e -c 'export VERBOSE=1;
-            export LIBDDWAF_INSTALL_PREFIX=/;
-            tar --strip-components=1 -xf ${{ env.artifactsDirectory }}/libddwaf-x86_64.tar.gz -C /usr/local/ &&
-            mkdir buildAG && cd buildAG &&
-            cmake ${{ github.workspace }} -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DCMAKE_C_FLAGS="-fno-omit-frame-pointer" &&
+          docker run --name pwaf_java_build -u $(id -u):$(id -g) -w ${{ github.workspace }} -v ${{ github.workspace }}:${{ github.workspace }} linux_cmake bash -e -c 'export VERBOSE=1;
+            export LIBDDWAF_INSTALL_PREFIX=${{ github.workspace }}/libddwaf/out;
+            set -x;
+            mkdir buildAG &&
+            cd buildAG &&
+            cmake ${{ github.workspace }} -DCMAKE_PREFIX_PATH=$LIBDDWAF_INSTALL_PREFIX/share/cmake/libddwaf -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DCMAKE_C_FLAGS="-fno-omit-frame-pointer" &&
             make -j &&
-            cp -v /usr/local/lib/libddwaf.so ${{ github.workspace }}/native_libs/linux/x86_64 &&
-            cp -v *.so ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
+            mkdir -p ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
+            cp -v $LIBDDWAF_INSTALL_PREFIX/lib/libddwaf.so ${{ github.workspace }}/native_libs/linux/x86_64 &&
+            cp -v $LIBDDWAF_INSTALL_PREFIX/lib/.build-id/*/*.debug ${{ github.workspace }}/native_libs/linux/x86_64/libddwaf.so.debug &&
+            cp -v *.so *.so.debug ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
             cd ${{ github.workspace }} &&
             ./gradlew check --info -PuseReleaseBinaries'
         shell: bash
-      - name: Copy binaries and debug symbols
-        run: |
-          sudo chown -R $(whoami) "${{ env.tempdir }}"
-          mkdir ${{ env.tempdir }}/packages
-          cd ${{ env.tempdir }}/packages
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so .
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so.debug .
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.tempdir }}/packages
+          path: native_libs
           name: jni_${{ env.artifactsuff }}
 
   Native_binaries_Stage_linux_x86_64_musl:
@@ -426,46 +395,39 @@ jobs:
       dockerfile: ci/alpine
       artifactsuff: linux_musl-x86_64
       libdir: linux/x86_64/musl
-      artifactsDirectory: ${{ github.workspace }}/artifacts
     steps: # identical to glibc
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           clean: true
-      - name: Create artifacts directory
-        run: mkdir -p ${{ env.artifactsDirectory }}
       - name: Download libddwaf artifact
         uses: actions/download-artifact@v4
         with:
           name: libddwaf_linux-x86_64
-          path: ${{ env.artifactsDirectory }}
+          path: libddwaf/out
       - name: Build docker linux image
         run: docker build ${{ env.dockerfile  }} -t linux_cmake
       - name: Build and test with release binaries
         run: |
-          docker run --name pwaf_java_build -v $(pwd):${{ github.workspace }} linux_cmake bash -e -c 'export VERBOSE=1;
-            export LIBDDWAF_INSTALL_PREFIX=/;
-            tar --strip-components=1 -xvf ${{ env.artifactsDirectory }}/libddwaf-x86_64.tar.gz -C /usr/local/ &&
-            mkdir buildAG && cd buildAG &&
-            cmake ${{ github.workspace }} -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DCMAKE_C_FLAGS="-fno-omit-frame-pointer" &&
+          docker run --name pwaf_java_build -u $(id -u):$(id -g) -w ${{ github.workspace }} -v ${{ github.workspace }}:${{ github.workspace }} linux_cmake bash -e -c 'export VERBOSE=1;
+            export LIBDDWAF_INSTALL_PREFIX=${{ github.workspace }}/libddwaf/out;
+            set -x;
+            mkdir buildAG &&
+            cd buildAG &&
+            cmake ${{ github.workspace }} -DCMAKE_PREFIX_PATH=$LIBDDWAF_INSTALL_PREFIX/share/cmake/libddwaf -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DCMAKE_C_FLAGS="-fno-omit-frame-pointer" &&
             make -j &&
-            cp -v /usr/local/lib/libddwaf.so ${{ github.workspace }}/native_libs/linux/x86_64 &&
-            cp -v *.so ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
+            mkdir -p ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
+            cp -v $LIBDDWAF_INSTALL_PREFIX/lib/libddwaf.so ${{ github.workspace }}/native_libs/linux/x86_64 &&
+            cp -v $LIBDDWAF_INSTALL_PREFIX/lib/.build-id/*/*.debug ${{ github.workspace }}/native_libs/linux/x86_64/libddwaf.so.debug &&
+            cp -v *.so *.so.debug ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
             cd ${{ github.workspace }} &&
             ./gradlew check --info -PuseReleaseBinaries'
         shell: bash
-      - name: Copy binaries and debug symbols
-        run: |
-          sudo chown -R $(whoami) ${{ env.tempdir }}
-          mkdir ${{ env.tempdir }}/packages
-          cd ${{ env.tempdir }}/packages
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so .
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so.debug .
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.tempdir }}/packages
+          path: native_libs
           name: jni_${{ env.artifactsuff }}
 
   Native_binaries_Stage_linux_aarch64_glibc:
@@ -477,7 +439,6 @@ jobs:
       dockerfile: ci/manylinux/aarch64
       artifactsuff: linux_glibc-aarch64
       libdir: linux/aarch64/glibc
-      artifactsDirectory: ${{ github.workspace }}/artifacts
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -486,43 +447,34 @@ jobs:
           clean: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      - name: Create artifacts directory
-        run: mkdir -p ${{ env.artifactsDirectory }}
       - name: Download libddwaf artifact
         uses: actions/download-artifact@v4
         with:
           name: libddwaf_linux-aarch64
-          path: ${{ env.artifactsDirectory }}
+          path: libddwaf/out
       - name: Build docker linux image
         run: docker build --platform linux/arm64 ${{ env.dockerfile  }} -t linux_cmake_aarch64
       - name: Build and test JNI binding
         run: |
-          docker run --platform arm64 --name pwaf_java_build -v $(pwd):${{ github.workspace }} linux_cmake_aarch64 bash -e -c 'export VERBOSE=1;
-            export LIBDDWAF_INSTALL_PREFIX=/;
-            git config --global --add safe.directory /home/runner/work/libddwaf-java/libddwaf-java &&
-            tar --strip-components=1 -xf ${{ env.artifactsDirectory }}/libddwaf-aarch64.tar.gz -C /usr/local/ &&
-            mkdir buildAG && cd buildAG &&
-            cmake ${{ github.workspace }} -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DCMAKE_C_FLAGS="-fno-omit-frame-pointer" &&
+          docker run --platform arm64 --name pwaf_java_build -u $(id -u):$(id -g) -w ${{ github.workspace }} -v ${{ github.workspace }}:${{ github.workspace }} linux_cmake_aarch64 bash -e -c 'export VERBOSE=1;
+            export LIBDDWAF_INSTALL_PREFIX=${{ github.workspace }}/libddwaf/out;
+            set -x;
+            mkdir buildAG &&
+            cd buildAG &&
+            cmake ${{ github.workspace }} -DCMAKE_PREFIX_PATH=$LIBDDWAF_INSTALL_PREFIX/share/cmake/libddwaf -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DCMAKE_C_FLAGS="-fno-omit-frame-pointer" &&
             make -j &&
-            cp -v /usr/local/lib/libddwaf.so ${{ github.workspace }}/native_libs/linux/aarch64 &&
-            cp -v *.so /usr/local/lib/libddwaf.so ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
+            mkdir -p ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
+            cp -v $LIBDDWAF_INSTALL_PREFIX/lib/libddwaf.so ${{ github.workspace }}/native_libs/linux/aarch64/ &&
+            cp -v $LIBDDWAF_INSTALL_PREFIX/lib/.build-id/*/*.debug ${{ github.workspace }}/native_libs/linux/aarch64/libddwaf.so.debug &&
+            cp -v *.so *.so.debug ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
             cd ${{ github.workspace }} &&
             ./gradlew check --info -PuseReleaseBinaries'
         shell: bash
-      - name: Copy binaries and debug symbols
-        run: |
-          sudo chown -R $(whoami) "${{ env.tempdir }}"
-          mkdir ${{ env.tempdir }}/packages
-          cd ${{ env.tempdir }}/packages
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so .
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so.debug .
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.tempdir }}/packages
+          path: native_libs
           name: jni_${{ env.artifactsuff }}
-      - name: Cleanup
-        run: sudo git clean -ffdx
 
   Native_binaries_Stage_linux_aarch64_musl:
     name: Linux aarch64 (musl)
@@ -533,7 +485,6 @@ jobs:
       dockerfile: ci/alpine
       artifactsuff: linux_musl-aarch64
       libdir: linux/aarch64/musl
-      artifactsDirectory: ${{ github.workspace }}/artifacts
     steps: # identical to glibc
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -542,42 +493,34 @@ jobs:
           clean: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      - name: Create artifacts directory
-        run: mkdir -p ${{ env.artifactsDirectory }}
       - name: Download libddwaf artifact
         uses: actions/download-artifact@v4
         with:
           name: libddwaf_linux-aarch64
-          path: ${{ env.artifactsDirectory }}
+          path: libddwaf/out
       - name: Build docker linux image
         run: docker build --platform linux/arm64 ${{ env.dockerfile  }} -t linux_cmake
       - name: Build and test with release binaries
         run: |
-          docker run --platform linux/arm64 --name pwaf_java_build -v $(pwd):${{ github.workspace }} linux_cmake bash -e -c 'export VERBOSE=1;
-            export LIBDDWAF_INSTALL_PREFIX=/;
-            tar --strip-components=1 -xvf ${{ env.artifactsDirectory }}/libddwaf-aarch64.tar.gz -C /usr/local/ &&
-            mkdir buildAG && cd buildAG &&
-            cmake ${{ github.workspace }} -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DCMAKE_C_FLAGS="-fno-omit-frame-pointer" &&
+          docker run --platform linux/arm64 --name pwaf_java_build -u $(id -u):$(id -g) -w ${{ github.workspace }} -v ${{ github.workspace }}:${{ github.workspace }} linux_cmake bash -e -c 'export VERBOSE=1;
+            export LIBDDWAF_INSTALL_PREFIX=${{ github.workspace }}/libddwaf/out;
+            set -x;
+            mkdir buildAG &&
+            cd buildAG &&
+            cmake ${{ github.workspace }} -DCMAKE_PREFIX_PATH=$LIBDDWAF_INSTALL_PREFIX/share/cmake/libddwaf -DCMAKE_BUILD_TYPE=${{ env.buildType }} -DCMAKE_C_FLAGS="-fno-omit-frame-pointer" &&
             make -j &&
-            cp -v /usr/local/lib/libddwaf.so ${{ github.workspace }}/native_libs/linux/aarch64 &&
-            cp -v *.so ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
+            mkdir -p ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
+            cp -v $LIBDDWAF_INSTALL_PREFIX/lib/libddwaf.so ${{ github.workspace }}/native_libs/linux/aarch64/ &&
+            cp -v $LIBDDWAF_INSTALL_PREFIX/lib/.build-id/*/*.debug ${{ github.workspace }}/native_libs/linux/aarch64/libddwaf.so.debug &&
+            cp -v *.so *.so.debug ${{ github.workspace }}/native_libs/${{ env.libdir }} &&
             cd ${{ github.workspace }} &&
             ./gradlew check --info -PuseReleaseBinaries'
         shell: bash
-      - name: Copy binaries and debug symbols
-        run: |
-          sudo chown -R $(whoami) ${{ env.tempdir }}
-          mkdir ${{ env.tempdir }}/packages
-          cd ${{ env.tempdir }}/packages
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so .
-          docker cp pwaf_java_build:/buildAG/libsqreen_jni.so.debug .
       - name: Save Artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.tempdir }}/packages
+          path: native_libs
           name: jni_${{ env.artifactsuff }}
-      - name: Cleanup
-        run: sudo git clean -ffdx
 
   Native_binaries_Stage_asan:
     name: ASAN/static analyzer on Linux
@@ -633,8 +576,6 @@ jobs:
   Jar_File_Stage_build_jar:
     name: Build & Publish
     runs-on: ubuntu-20.04
-    env:
-      artifactsDirectory: ${{ github.workspace }}/artifacts
     needs:
       - Native_binaries_Stage_macos_x86_64
       - Native_binaries_Stage_macos_aarch64
@@ -644,8 +585,6 @@ jobs:
       - Native_binaries_Stage_linux_aarch64_glibc
       - Native_binaries_Stage_linux_aarch64_musl
       - Native_binaries_Stage_asan
-      - Native_binaries_Stage_libddwaf_linux_x86_64
-      - Native_binaries_Stage_libddwaf_linux_aarch64
     steps:
     - name: Setup JDK 1.8
       uses: actions/setup-java@v1
@@ -660,72 +599,39 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: libsqreen_jni_win-x86_64
-        path: ${{ env.artifactsDirectory }}/libsqreen_jni_win-x86_64
-    - name: Download libddwaf_linux-x86_64
-      uses: actions/download-artifact@v4
-      with:
-        name: libddwaf_linux-x86_64
-        path: ${{ env.artifactsDirectory }}/libsqreen_linux-x86_64
-    - name: Download libddwaf_linux-aarch64
-      uses: actions/download-artifact@v4
-      with:
-        name: libddwaf_linux-aarch64
-        path: ${{ env.artifactsDirectory }}/libsqreen_linux-aarch64
+        path: native_libs
     - name: Download jni_linux_glibc-x86_64
       uses: actions/download-artifact@v4
       with:
         name: jni_linux_glibc-x86_64
-        path: ${{ env.artifactsDirectory }}/jni_linux_glibc-x86_64
+        path: native_libs
     - name: Download jni_linux_glibc-aarch64
       uses: actions/download-artifact@v4
       with:
         name: jni_linux_glibc-aarch64
-        path: ${{ env.artifactsDirectory }}/jni_linux_glibc-aarch64
+        path: native_libs
     - name: Download jni_linux_musl-x86_64
       uses: actions/download-artifact@v4
       with:
         name: jni_linux_musl-x86_64
-        path: ${{ env.artifactsDirectory }}/jni_linux_musl-x86_64
+        path: native_libs
     - name: Download jni_linux_musl-aarch64
       uses: actions/download-artifact@v4
       with:
         name: jni_linux_musl-aarch64
-        path: ${{ env.artifactsDirectory }}/jni_linux_musl-aarch64
+        path: native_libs
     - name: Download libsqreen_jni_macos-x86_64
       uses: actions/download-artifact@v4
       with:
         name: libsqreen_jni_macos-x86_64
-        path: ${{ env.artifactsDirectory }}/libsqreen_jni_macos-x86_64
+        path: native_libs
     - name: Download libsqreen_jni_macos_aarch64
       uses: actions/download-artifact@v4
       with:
         name: libsqreen_jni_macos-aarch64
-        path: ${{ env.artifactsDirectory }}/libsqreen_jni_macos-aarch64
+        path: native_libs
     - run: find .
-      working-directory: ${{ env.artifactsDirectory }}
-    - name: Copy the artifacts to the correct directories
-      run: |
-        set -ex
-        cp ${{ env.artifactsDirectory }}/libsqreen_jni_win-x86_64/* native_libs/windows/x86_64/
-        LIBDDWAF_TAR="${{ env.artifactsDirectory }}/libsqreen_linux-x86_64/libddwaf-x86_64.tar.gz"
-        tar -xvf "$LIBDDWAF_TAR" -C native_libs/linux/x86_64/ --strip-components=2 `tar -tf "$LIBDDWAF_TAR" | grep '\.so$'`
-        tar -xvf "$LIBDDWAF_TAR" -C native_libs/linux/x86_64/ --strip-components=4 `tar -tf "$LIBDDWAF_TAR" | grep '\.debug$'`
-        mv native_libs/linux/x86_64/*.debug native_libs/linux/x86_64/libddwaf.so.debug
-        
-        LIBDDWAF_TAR="${{ env.artifactsDirectory }}/libsqreen_linux-aarch64/libddwaf-aarch64.tar.gz"
-        tar -xvf "$LIBDDWAF_TAR" -C native_libs/linux/aarch64/ --strip-components=2 `tar -tf "$LIBDDWAF_TAR" | grep '\.so$'`
-        tar -xvf "$LIBDDWAF_TAR" -C native_libs/linux/aarch64/ --strip-components=4 `tar -tf "$LIBDDWAF_TAR" | grep '\.debug$'`
-        mv native_libs/linux/aarch64/*.debug native_libs/linux/aarch64/libddwaf.so.debug
-        
-        cp ${{ env.artifactsDirectory }}/jni_linux_glibc-x86_64/* native_libs/linux/x86_64/glibc/
-        cp ${{ env.artifactsDirectory }}/jni_linux_musl-x86_64/* native_libs/linux/x86_64/musl/
-        
-        cp ${{ env.artifactsDirectory }}/jni_linux_glibc-aarch64/* native_libs/linux/aarch64/glibc/
-        cp ${{ env.artifactsDirectory }}/jni_linux_musl-aarch64/* native_libs/linux/aarch64/musl/
-        
-        cp ${{ env.artifactsDirectory }}/libsqreen_jni_macos-x86_64/* native_libs/macos/x86_64/
-        cp ${{ env.artifactsDirectory }}/libsqreen_jni_macos-aarch64/* native_libs/macos/aarch64/
-      shell: bash
+      working-directory: native_libs
     - name: Cache Gradle artifacts
       uses: actions/cache@v2
       with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -70,8 +70,6 @@ jobs:
       run: cmake -E make_directory "${{ env.tempdir }}/buildPW"
     - name: Create Build Directory for JNI binding
       run: cmake -E make_directory "${{ env.tempdir }}/buildAG"
-    - name: Create Packages Directory
-      run: cmake -E make_directory ${{ env.tempdir }}/packages
     - name: Generate Build Scripts for libddwaf
       run: |
         cmake -DCMAKE_BUILD_TYPE=${{ env.buildType }} \
@@ -97,8 +95,6 @@ jobs:
     - name: Build Binaries for JNI Binding
       run: cmake --build . --verbose
       working-directory: ${{ env.tempdir }}/buildAG
-    - name: Create packages directory
-      run: mkdir -p ${{ github.workspace }}/native_libs/${{ env.libdir }}
     - name: Copy libddwaf binaries to native_libs
       run: |
         cmake -E copy ${{ env.shlib_prefix }}ddwaf.${{ env.shlib_ext }} \
@@ -152,8 +148,6 @@ jobs:
         run: cmake -E make_directory "${{ env.tempdir }}/buildPW"
       - name: Create Build Directory for JNI binding
         run: cmake -E make_directory "${{ env.tempdir }}/buildAG"
-      - name: Create Packages Directory
-        run: cmake -E make_directory ${{ env.tempdir }}/packages
       - name: Generate Build Scripts for libddwaf
         run: |
           cmake -DCMAKE_OSX_ARCHITECTURES=arm64 \
@@ -181,8 +175,6 @@ jobs:
       - name: Build Binaries for JNI Binding
         run: cmake --build .
         working-directory: ${{ env.tempdir }}/buildAG
-      - name: Create packages directory
-        run: mkdir -p ${{ github.workspace }}/native_libs/${{ env.libdir }}
       - name: Copy libddwaf binaries to native_libs
         run: |
           cmake -E copy ${{ env.shlib_prefix }}ddwaf.${{ env.shlib_ext }} \
@@ -262,14 +254,8 @@ jobs:
       - name: Build Binaries for JNI Binding
         run: cmake --build .
         working-directory: ${{ env.tempdir }}/buildAG
-      - name: Create packages directory
-        run: cmake -E make_directory ${{ github.workspace }}/native_libs/${{ env.libdir }}
-      - name: Copy JNI binding binaries to packages
-        run: cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} ${{ github.workspace }}\build\native_libs\${{ env.libdir }}
-        shell: cmd
-        working-directory: ${{ env.tempdir }}/buildAG
-      - name: Copy JNI binding binaries to native_libs (testing)
-        run: cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} ${{ github.workspace }}\build\native_libs\${{ env.libdir }}
+      - name: Copy JNI binding binaries to native_libs
+        run: cmake -E copy ${{ env.shlib_prefix }}sqreen_jni.${{ env.shlib_ext }} ${{ env.shlib_prefix }}sqreen_jni.${{ env.debug_ext }} ${{ github.workspace }}\native_libs\${{ env.libdir }}
         shell: cmd
         working-directory: ${{ env.tempdir }}/buildAG
       - name: Cache Gradle artifacts

--- a/ci/alpine-libc++-static/aarch64/Dockerfile
+++ b/ci/alpine-libc++-static/aarch64/Dockerfile
@@ -9,6 +9,9 @@ RUN mkdir /tmp/apk && cd /tmp/apk && \
 
 FROM build_env AS libddwaf_build
 COPY . /AgentJavaNative
+RUN mkdir -p /build /out
+WORKDIR /build
+
 # NOTES:
 #    CMAKE_CXX_FLAGS (except -stdlib=libc++) and CMAKE_C_FLAGS are only used to
 #    pass the cmake compiler sanity checks. They have no effect otherwise due to
@@ -16,9 +19,8 @@ COPY . /AgentJavaNative
 #    -static-libgcc is used to force libunwind to be compiled statically
 #    (-l:libwind.a instead of -lunwind), it has nothing to do with libgcc.
 #    Again, this is only needed for the cmake sanity checks.
-RUN mkdir /build && cd /build && cmake /AgentJavaNative/libddwaf \
+RUN cd /build && cmake /AgentJavaNative/libddwaf \
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
-	-DCMAKE_INSTALL_PREFIX=/usr \
 	-DCMAKE_C_COMPILER=clang \
 	-DCMAKE_CXX_COMPILER=clang++ \
 	-DCMAKE_CXX_FLAGS="-stdlib=libc++ -Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -fno-omit-frame-pointer" \
@@ -31,9 +33,9 @@ RUN mkdir /build && cd /build && cmake /AgentJavaNative/libddwaf \
 # because in musl these are all empty libraries. The symbols live in libc, and
 # will be imported. When linking to the shared library in a glibc system,
 # -lm, -ldl, -lpthread need to be provided though
-RUN cd /build && VERBOSE=1 make -j
+RUN cmake --build . --parallel
 RUN patchelf --remove-needed libc.musl-aarch64.so.1 /build/libddwaf.so
-RUN cd /build && make package && mv libddwaf-*.tar.gz libddwaf-aarch64.tar.gz
+RUN cmake --install . --prefix /out
 
 FROM scratch
-COPY --from=libddwaf_build /build/libddwaf-aarch64.tar.gz /
+COPY --from=libddwaf_build /out/ /

--- a/ci/alpine-libc++-static/x86_64/Dockerfile
+++ b/ci/alpine-libc++-static/x86_64/Dockerfile
@@ -9,6 +9,9 @@ RUN mkdir /tmp/apk && cd /tmp/apk && \
 
 FROM build_env AS libddwaf_build
 COPY .. /AgentJavaNative
+RUN mkdir -p /build
+WORKDIR /build
+
 # NOTES:
 #    CMAKE_CXX_FLAGS (except -stdlib=libc++) and CMAKE_C_FLAGS are only used to
 #    pass the cmake compiler sanity checks. They have no effect otherwise due to
@@ -16,9 +19,8 @@ COPY .. /AgentJavaNative
 #    -static-libgcc is used to force libunwind to be compiled statically
 #    (-l:libwind.a instead of -lunwind), it has nothing to do with libgcc.
 #    Again, this is only needed for the cmake sanity checks.
-RUN mkdir /build && cd /build && cmake /AgentJavaNative/libddwaf \
+RUN cmake /AgentJavaNative/libddwaf \
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
-	-DCMAKE_INSTALL_PREFIX=/usr \
 	-DCMAKE_C_COMPILER=clang \
 	-DCMAKE_CXX_COMPILER=clang++ \
 	-DCMAKE_CXX_FLAGS="-stdlib=libc++ -Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -fno-omit-frame-pointer" \
@@ -31,9 +33,9 @@ RUN mkdir /build && cd /build && cmake /AgentJavaNative/libddwaf \
 # because in musl these are all empty libraries. The symbols live in libc, and
 # will be imported. When linking to the shared library in a glibc system,
 # -lm, -ldl, -lpthread need to be provided though
-RUN cd /build && VERBOSE=1 make -j
+RUN cmake --build . --parallel
 RUN patchelf --remove-needed libc.musl-x86_64.so.1 /build/libddwaf.so
-RUN cd /build && make package && mv libddwaf-*.tar.gz libddwaf-x86_64.tar.gz
+RUN cmake --install . --prefix /out
 
 FROM scratch
-COPY --from=libddwaf_build /build/libddwaf-x86_64.tar.gz /
+COPY --from=libddwaf_build /out/ /


### PR DESCRIPTION
Reduce the amount of back and forth copying of built artifacts, reducing it to just two paths:
* `libddwaf/out` for the intermediate libddwaf build (to be consumed only by Linux bindings build steps)
* `native_libs` for all artifacts to be used by the final gradle build and tests.
* Run Docker containers with the host user and avoid `chown` and any other permission tweaking.