### PR TITLE
Test development workflows in CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -503,6 +503,45 @@ jobs:
           LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.8 \
           ./gradlew --build-cache -x buildNativeLibDebug --info test
       shell: bash
+
+  Dev_Tests:
+    # Used to test our development workflow for debug builds.
+    # This should be in sync with whatever we document in the README.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: ubuntu-22.04
+          # FIXME: Use macos-14 once https://bugs.openjdk.org/browse/JDK-8205076 is solved.
+          - runs-on: macos-12
+    name: Development tests
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        clean: true
+    - name: Setup JDK 1.8
+      uses: actions/setup-java@v4
+      with:
+        java-version: 8
+        distribution: temurin
+    - name: Build libddwaf
+      run: |
+        set -ex
+        cd libddwaf
+        mkdir Debug && cd Debug
+        cmake .. -DCMAKE_BUILD_TYPE=Debug
+        VERBOSE=1 make -j
+        DESTDIR=out make install
+    - name: Build JNI bindings
+      run: |
+        ./gradlew buildNativeLibDebug --rerun-tasks
+    - name: Run tests
+      run: |
+        ./gradlew check
+
   Jar_File_Stage_build_jar:
     name: Build
     runs-on: ubuntu-20.04
@@ -730,6 +769,7 @@ jobs:
     name: Tests pass
     needs:
       - Test
+      - Dev_Tests
       - Jar_File_Stage_build_jar
     runs-on: ubuntu-20.04
     steps:
@@ -740,8 +780,9 @@ jobs:
     name: Publish
     runs-on: ubuntu-20.04
     needs:
-      - Jar_File_Stage_build_jar
       - Test
+      - Dev_Tests
+      - Jar_File_Stage_build_jar
     if: contains(github.ref, 'refs/tags/v')
     steps:
     - name: Download artifacts


### PR DESCRIPTION
The way we build for development and debugging is significantly different from our release builds. This PR tests our local development workflow as documented in `README.md`. This will help ensuring we do not break it when going for further refactors.