### PR TITLE
Upgrade to libddwaf 1.16.1

### DIFF
--- a/src/main/java/io/sqreen/powerwaf/Powerwaf.java
+++ b/src/main/java/io/sqreen/powerwaf/Powerwaf.java
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 
 public final class Powerwaf {
-    public static final String LIB_VERSION = "1.16.0";
+    public static final String LIB_VERSION = "1.16.1";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Powerwaf.class);
     static final boolean ENABLE_BYTE_BUFFERS;


### PR DESCRIPTION
Upgrade to [1.16.1](https://github.com/DataDog/libddwaf/releases/tag/1.16.1) patch release for work related to re-using libddwaf builds for libddwaf-java. No need to trigger a release for this since it has no impact with our current build process.