### PR TITLE
Split build and test JDKs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -590,52 +590,53 @@ jobs:
           - runs-on: ubuntu-20.04
             os: linux
             arch: x86_64
-            jdk: temurin8
-            docker_image: eclipse-temurin:8-jdk-focal
+            docker_image: ubuntu2204-temurin8
+            test_java_home_var: JAVA_8_HOME
           - runs-on: ubuntu-20.04
             os: linux
             arch: x86_64
-            jdk: temurin11
-            docker_image: eclipse-temurin:11-jdk-focal
+            docker_image: ubuntu2204-temurin11
+            test_java_home_var: JAVA_11_HOME
           - runs-on: ubuntu-20.04
             os: linux
             arch: x86_64
-            jdk: temurin17
-            docker_image: eclipse-temurin:17-jdk-focal
-          # FIXME: codearc plugin fails with java 21, we'll need to wait for a fix
-          #        or split compile and test jdk.
-          #- runs-on: ubuntu-20.04
-          #  os: linux
-          #  arch: x86_64
-          #  jdk: temurin21
-          #  docker_image: eclipse-temurin:21-jdk-jammy
+            docker_image: ubuntu2204-temurin17
+            test_java_home_var: JAVA_17_HOME
           - runs-on: ubuntu-20.04
             os: linux
             arch: x86_64
-            jdk: temurin8
-            docker_image: eclipse-temurin:8-jdk-centos7
+            docker_image: ubuntu2204-temurin21
+            test_java_home_var: JAVA_21_HOME
           - runs-on: ubuntu-20.04
             os: linux
             arch: x86_64
-            jdk: temurin8
-            docker_image: eclipse-temurin:8-jdk-alpine
+            docker_image: centos7-stock8
+            test_java_home_var: JAVA_8_HOME
           - runs-on: ubuntu-20.04
             os: linux
             arch: x86_64
-            jdk: redhat8
-            docker_image: centos6:custom
-            docker_image_dir: ci/centos6
+            docker_image: alpine-stock8
+            test_java_home_var: JAVA_8_HOME
+          - runs-on: ubuntu-20.04
+            os: linux
+            arch: x86_64
+            docker_image: centos6-stock8
+            test_java_home_var: JAVA_8_HOME
           # FIXME: We have a JNI check failure with OpenJ9.
           #- runs-on: ubuntu-20.04
           #  os: linux
           #  arch: x86_64
-          #  jdk: semeru8
           #  docker_image: ibm-semeru-runtimes:open-8-jdk-centos7
           - runs-on: arm-4core-linux
             os: linux
             arch: aarch64
-            jdk: temurin8
-            docker_image: eclipse-temurin:8-jdk-focal
+            docker_image: ubuntu2204-temurin8
+            test_java_home_var: JAVA_8_HOME
+          - runs-on: arm-4core-linux
+            os: linux
+            arch: aarch64
+            docker_image: alpine-stock8
+            test_java_home_var: JAVA_8_HOME
           # FIXME: Gradle daemon crashes
           #- runs-on: macos-11
           #  os: macos
@@ -701,10 +702,12 @@ jobs:
         sudo sh get-docker.sh
       if: ${{ matrix.runs-on == 'arm-4core-linux' }}
     - name: Build Docker image
-      run: sudo docker build -t ${{ matrix.docker_image }} ${{ matrix.docker_image_dir }}
-      if: ${{ matrix.docker_image_dir != '' }}
+      run: sudo docker build -t ${{ matrix.docker_image }} ci/${{ matrix.docker_image }}
+      if: ${{ matrix.docker_image != '' }}
     - name: Run tests (docker)
-      run: sudo docker run --rm -w $(pwd) -v $(pwd):$(pwd) ${{ matrix.docker_image }} sh -c './gradlew check --no-daemon --info -Prelease -PuseReleaseBinaries -Dorg.gradle.native=false'
+      run: |
+        sudo docker run --rm -w $(pwd) -v $(pwd):$(pwd) ${{ matrix.docker_image }} \
+          sh -c './gradlew check --no-daemon --info -Prelease -PuseReleaseBinaries -Dorg.gradle.native=false -PtestJavaHome="$${{ matrix.test_java_home_var }}"'
       if: ${{ matrix.os == 'linux' }}
     - name: Run tests (no docker)
       run: |

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ import com.amazonaws.auth.EnvironmentVariableCredentialsProvider
 import com.amazonaws.auth.profile.*
 import com.amazonaws.services.s3.*
 import com.amazonaws.services.s3.model.*
+import org.gradle.jvm.toolchain.internal.SpecificInstallationToolchainSpec
 
 buildscript {
     repositories {
@@ -430,6 +431,25 @@ codenarc {
 codenarcTest {
     compilationClasspath = codenarcMain.compilationClasspath +
             sourceSets.test.compileClasspath + sourceSets.test.output
+}
+
+// Select alternative JVM for tests.
+// Based on https://github.com/DataDog/dd-trace-java/blob/master/gradle/java_no_deps.gradle
+project.afterEvaluate {
+    def testJavaHome = gradle.startParameter.projectProperties["testJavaHome"]
+    if (testJavaHome != null) {
+        def jvmSpec = new SpecificInstallationToolchainSpec(project.getObjects(), file(testJavaHome))
+        Provider<JavaLauncher> launcher = providers.provider {
+            try {
+                return javaToolchains.launcherFor(jvmSpec).get()
+            } catch (NoSuchElementException ignored) {
+                throw new GradleException("Unable to find launcher for Java $testJavaHome")
+            }
+        }
+        tasks.withType(Test).configureEach {
+            javaLauncher = launcher
+        }
+    }
 }
 
 // vim: set et ts=4 sw=4 list:

--- a/ci/alpine-stock8/Dockerfile
+++ b/ci/alpine-stock8/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.19
+RUN apk add --no-cache bash openjdk8
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
+ENV JAVA_8_HOME=/usr/lib/jvm/java-1.8-openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH

--- a/ci/centos6-stock8/Dockerfile
+++ b/ci/centos6-stock8/Dockerfile
@@ -1,0 +1,6 @@
+FROM centos:6
+RUN set -eux; \
+    curl https://www.getpagespeed.com/files/centos6-eol.repo --output /etc/yum.repos.d/CentOS-Base.repo; \
+    yum install -y java-1.8.0-openjdk-devel
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk.x86_64
+ENV JAVA_8_HOME=/usr/lib/jvm/java-1.8.0-openjdk.x86_64

--- a/ci/centos6/Dockerfile
+++ b/ci/centos6/Dockerfile
@@ -1,4 +1,0 @@
-FROM centos:6
-RUN set -eux; \
-    curl https://www.getpagespeed.com/files/centos6-eol.repo --output /etc/yum.repos.d/CentOS-Base.repo; \
-    yum install -y java-1.8.0-openjdk-devel

--- a/ci/centos7-stock8/Dockerfile
+++ b/ci/centos7-stock8/Dockerfile
@@ -1,0 +1,4 @@
+FROM centos:7
+RUN yum install -y java-1.8.0-openjdk-devel
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
+ENV JAVA_8_HOME=/usr/lib/jvm/java-1.8.0-openjdk

--- a/ci/ubuntu2204-temurin11/Dockerfile
+++ b/ci/ubuntu2204-temurin11/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:22.04
+COPY --from=eclipse-temurin:8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/8
+ENV JAVA_HOME=/usr/lib/jvm/8
+ENV JAVA_8_HOME=/usr/lib/jvm/8
+COPY --from=eclipse-temurin:11-jdk-jammy /opt/java/openjdk /usr/lib/jvm/11
+ENV JAVA_11_HOME=/usr/lib/jvm/11

--- a/ci/ubuntu2204-temurin17/Dockerfile
+++ b/ci/ubuntu2204-temurin17/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:22.04
+COPY --from=eclipse-temurin:8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/8
+ENV JAVA_HOME=/usr/lib/jvm/8
+ENV JAVA_8_HOME=/usr/lib/jvm/8
+COPY --from=eclipse-temurin:17-jdk-jammy /opt/java/openjdk /usr/lib/jvm/17
+ENV JAVA_17_HOME=/usr/lib/jvm/17

--- a/ci/ubuntu2204-temurin21/Dockerfile
+++ b/ci/ubuntu2204-temurin21/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:22.04
+COPY --from=eclipse-temurin:8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/8
+ENV JAVA_HOME=/usr/lib/jvm/8
+ENV JAVA_8_HOME=/usr/lib/jvm/8
+COPY --from=eclipse-temurin:21-jdk-jammy /opt/java/openjdk /usr/lib/jvm/21
+ENV JAVA_21_HOME=/usr/lib/jvm/21

--- a/ci/ubuntu2204-temurin8/Dockerfile
+++ b/ci/ubuntu2204-temurin8/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:22.04
+COPY --from=eclipse-temurin:8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/8
+ENV JAVA_HOME=/usr/lib/jvm/8
+ENV JAVA_8_HOME=/usr/lib/jvm/8


### PR DESCRIPTION
This allows us to test in setups where our gradle work does not work (e.g. JDK 21, possibly some ARM64 variants, etc). Also enable tests on JDK 21, and Alpine in ARM64.