### PR TITLE
Test on Semeru JDKs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -424,6 +424,26 @@ jobs:
           - runs-on: ubuntu-20.04
             os: linux
             arch: x86_64
+            docker_image: ubuntu2204-semeru8
+            test_java_home_var: JAVA_SEMERU8_HOME
+          - runs-on: ubuntu-20.04
+            os: linux
+            arch: x86_64
+            docker_image: ubuntu2204-semeru11
+            test_java_home_var: JAVA_SEMERU11_HOME
+          - runs-on: ubuntu-20.04
+            os: linux
+            arch: x86_64
+            docker_image: ubuntu2204-semeru17
+            test_java_home_var: JAVA_SEMERU17_HOME
+          - runs-on: ubuntu-20.04
+            os: linux
+            arch: x86_64
+            docker_image: ubuntu2204-semeru21
+            test_java_home_var: JAVA_SEMERU21_HOME
+          - runs-on: ubuntu-20.04
+            os: linux
+            arch: x86_64
             docker_image: centos7-stock8
             test_java_home_var: JAVA_8_HOME
           - runs-on: ubuntu-20.04
@@ -436,11 +456,6 @@ jobs:
             arch: x86_64
             docker_image: centos6-stock8
             test_java_home_var: JAVA_8_HOME
-          # FIXME: We have a JNI check failure with OpenJ9.
-          #- runs-on: ubuntu-20.04
-          #  os: linux
-          #  arch: x86_64
-          #  docker_image: ibm-semeru-runtimes:open-8-jdk-centos7
           - runs-on: arm-4core-linux
             os: linux
             arch: aarch64

--- a/build.gradle
+++ b/build.gradle
@@ -384,12 +384,34 @@ task testNoByteBuffers(type: Test) {
 }
 check.dependsOn testNoByteBuffers
 
-tasks.withType(Test).each {
+tasks.withType(Test).configureEach {
     if (System.getenv('TEST_EXECUTABLE')) {
         it.executable System.getenv('TEST_EXECUTABLE')
     }
 
-    it.jvmArgs += ['-Xcheck:jni', '-Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG', '-DPOWERWAF_EXIT_ON_LEAK=true']
+    // Select alternative JVM for tests.
+    // Based on https://github.com/DataDog/dd-trace-java/blob/master/gradle/java_no_deps.gradle
+    def testJavaHome = gradle.startParameter.projectProperties["testJavaHome"]
+    if (testJavaHome != null) {
+        def jvmSpec = new SpecificInstallationToolchainSpec(project.getObjects(), file(testJavaHome))
+        Provider<JavaLauncher> launcher = providers.provider {
+            try {
+                return javaToolchains.launcherFor(jvmSpec).get()
+            } catch (NoSuchElementException ignored) {
+                throw new GradleException("Unable to find launcher for Java $testJavaHome")
+            }
+        }
+        it.javaLauncher = launcher
+    }
+
+    if (it.javaLauncher.get().metadata.vendor == "IBM") {
+        // FIXME(APPSEC-52250): We have JNI checks warnings with J9, so we make them non-fatal for now.
+        it.jvmArgs += ['-Xcheck:jni:nonfatal']
+    } else {
+        it.jvmArgs += ['-Xcheck:jni']
+    }
+
+    it.jvmArgs += ['-Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG', '-DPOWERWAF_EXIT_ON_LEAK=true']
     if (project.hasProperty('useReleaseBinaries')) {
         it.jvmArgs += ['-DuseReleaseBinaries=true']
         it.dependsOn copyNativeLibs
@@ -431,25 +453,6 @@ codenarc {
 codenarcTest {
     compilationClasspath = codenarcMain.compilationClasspath +
             sourceSets.test.compileClasspath + sourceSets.test.output
-}
-
-// Select alternative JVM for tests.
-// Based on https://github.com/DataDog/dd-trace-java/blob/master/gradle/java_no_deps.gradle
-project.afterEvaluate {
-    def testJavaHome = gradle.startParameter.projectProperties["testJavaHome"]
-    if (testJavaHome != null) {
-        def jvmSpec = new SpecificInstallationToolchainSpec(project.getObjects(), file(testJavaHome))
-        Provider<JavaLauncher> launcher = providers.provider {
-            try {
-                return javaToolchains.launcherFor(jvmSpec).get()
-            } catch (NoSuchElementException ignored) {
-                throw new GradleException("Unable to find launcher for Java $testJavaHome")
-            }
-        }
-        tasks.withType(Test).configureEach {
-            javaLauncher = launcher
-        }
-    }
 }
 
 // vim: set et ts=4 sw=4 list:

--- a/ci/ubuntu2204-semeru11/Dockerfile
+++ b/ci/ubuntu2204-semeru11/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:22.04
+COPY --from=eclipse-temurin:8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/8
+ENV JAVA_HOME=/usr/lib/jvm/8
+ENV JAVA_8_HOME=/usr/lib/jvm/8
+COPY --from=ibm-semeru-runtimes:open-11-jdk-jammy /opt/java/openjdk /usr/lib/jvm/semeru11
+ENV JAVA_SEMERU11_HOME=/usr/lib/jvm/semeru11

--- a/ci/ubuntu2204-semeru17/Dockerfile
+++ b/ci/ubuntu2204-semeru17/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:22.04
+COPY --from=eclipse-temurin:8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/8
+ENV JAVA_HOME=/usr/lib/jvm/8
+ENV JAVA_8_HOME=/usr/lib/jvm/8
+COPY --from=ibm-semeru-runtimes:open-17-jdk-jammy /opt/java/openjdk /usr/lib/jvm/semeru17
+ENV JAVA_SEMERU17_HOME=/usr/lib/jvm/semeru17

--- a/ci/ubuntu2204-semeru21/Dockerfile
+++ b/ci/ubuntu2204-semeru21/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:22.04
+COPY --from=eclipse-temurin:8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/8
+ENV JAVA_HOME=/usr/lib/jvm/8
+ENV JAVA_8_HOME=/usr/lib/jvm/8
+COPY --from=ibm-semeru-runtimes:open-21-jdk-jammy /opt/java/openjdk /usr/lib/jvm/semeru21
+ENV JAVA_SEMERU21_HOME=/usr/lib/jvm/semeru21

--- a/ci/ubuntu2204-semeru8/Dockerfile
+++ b/ci/ubuntu2204-semeru8/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:22.04
+COPY --from=eclipse-temurin:8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/8
+ENV JAVA_HOME=/usr/lib/jvm/8
+ENV JAVA_8_HOME=/usr/lib/jvm/8
+COPY --from=ibm-semeru-runtimes:open-8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/semeru8
+ENV JAVA_SEMERU8_HOME=/usr/lib/jvm/semeru8


### PR DESCRIPTION
* We currently have JNI check warnings on J9, so making them non-fatal but adding Semeru JDKs to CI.
* Part of [APPSEC-51927](https://datadoghq.atlassian.net/browse/APPSEC-51927).
* Warnings to be followed up at [APPSEC-52250](https://datadoghq.atlassian.net/browse/APPSEC-52250).

[APPSEC-51927]: https://datadoghq.atlassian.net/browse/APPSEC-51927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPSEC-52250]: https://datadoghq.atlassian.net/browse/APPSEC-52250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ