### PR TITLE
Add support for "exclusion_data"

### DIFF
--- a/src/main/c/output.c
+++ b/src/main/c/output.c
@@ -52,7 +52,7 @@ jobject output_convert_diagnostics_checked(JNIEnv *env, const ddwaf_object *obj)
     }
 
     jobject rules = NULL, custom_rules = NULL, rules_data = NULL,
-            rules_override = NULL, exclusions = NULL, ret = NULL;
+            rules_override = NULL, exclusions = NULL, ret = NULL, exclusion_data = NULL;
 
     rules = _convert_section_checked(env, obj, LSTR("rules"));
     if (JNI(ExceptionCheck)) {
@@ -74,9 +74,13 @@ jobject output_convert_diagnostics_checked(JNIEnv *env, const ddwaf_object *obj)
     if (JNI(ExceptionCheck)) {
         goto err;
     }
+    exclusion_data = _convert_section_checked(env, obj, LSTR("exclusion_data"));
+    if (JNI(ExceptionCheck)) {
+        goto err;
+    }
 
     ret = java_meth_call(env, &_rsi_init, NULL, rulesetVersion, rules,
-                         custom_rules, rules_data, rules_override, exclusions);
+                         custom_rules, rules_data, rules_override, exclusions, exclusion_data);
 
 err:
     if (rulesetVersion) {
@@ -97,6 +101,9 @@ err:
     if (exclusions) {
         JNI(DeleteLocalRef, exclusions);
     }
+    if (exclusion_data) {
+        JNI(DeleteLocalRef, exclusion_data);
+    }
     return ret;
 }
 
@@ -105,6 +112,7 @@ void output_init_checked(JNIEnv *env)
     if (!java_meth_init_checked(env, &_rsi_init,
                                 "io/sqreen/powerwaf/RuleSetInfo", "<init>",
                                 "(Ljava/lang/String;Lio/sqreen/powerwaf/"
+                                "RuleSetInfo$SectionInfo;Lio/sqreen/powerwaf/"
                                 "RuleSetInfo$SectionInfo;Lio/sqreen/powerwaf/"
                                 "RuleSetInfo$SectionInfo;Lio/sqreen/powerwaf/"
                                 "RuleSetInfo$SectionInfo;Lio/sqreen/powerwaf/"

--- a/src/main/java/io/sqreen/powerwaf/RuleSetInfo.java
+++ b/src/main/java/io/sqreen/powerwaf/RuleSetInfo.java
@@ -85,14 +85,16 @@ public class RuleSetInfo {
     public final SectionInfo rulesData;
     public final SectionInfo rulesOverride;
     public final SectionInfo exclusions;
+    public final SectionInfo exclusionData;
 
-    public RuleSetInfo(String rulesetVersion, SectionInfo rules, SectionInfo customRules, SectionInfo rulesData, SectionInfo rulesOverride, SectionInfo exclusions) {
+    public RuleSetInfo(String rulesetVersion, SectionInfo rules, SectionInfo customRules, SectionInfo rulesData, SectionInfo rulesOverride, SectionInfo exclusions, SectionInfo exclusionData) {
         this.rulesetVersion = rulesetVersion;
         this.rules = rules;
         this.customRules = customRules;
         this.rulesData = rulesData;
         this.rulesOverride = rulesOverride;
         this.exclusions = exclusions;
+        this.exclusionData = exclusionData;
     }
 
     public int getNumRulesOK() {
@@ -139,6 +141,7 @@ public class RuleSetInfo {
                 .add("rulesData=" + rulesData)
                 .add("rulesOverride=" + rulesOverride)
                 .add("exclusions=" + exclusions)
+                .add("exclusionData=" + exclusionData)
                 .toString();
     }
 }


### PR DESCRIPTION
Add support for the `exclusion_data` config object (see [RFC](https://docs.google.com/document/d/123wRO_ha5aZMzIXXJlGHobZrK8F4w5YuzyINncIQVLw/edit)) 

[APPSEC-54438](https://datadoghq.atlassian.net/browse/APPSEC-54438)

[APPSEC-54438]: https://datadoghq.atlassian.net/browse/APPSEC-54438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ