### PR TITLE
Fix derivatives parsing in the WAF response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ repositories {
 }
 
 group 'io.sqreen'
-version '11.0.0'
+version '11.0.1'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/test/groovy/io/sqreen/powerwaf/FingerprintTests.groovy
+++ b/src/test/groovy/io/sqreen/powerwaf/FingerprintTests.groovy
@@ -6,6 +6,7 @@ import org.junit.Test
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.contains
 import static org.hamcrest.Matchers.is
+import static org.hamcrest.Matchers.matchesPattern
 
 class FingerprintTests implements PowerwafTrait {
 
@@ -97,5 +98,6 @@ class FingerprintTests implements PowerwafTrait {
         )
         assertThat res.result, is(Powerwaf.Result.MATCH)
         assertThat res.derivatives.keySet(), contains('_dd.appsec.fp.http.endpoint')
+        assertThat res.derivatives['_dd.appsec.fp.http.endpoint'], matchesPattern('http-get-.*')
     }
 }

--- a/src/test/groovy/io/sqreen/powerwaf/SchemaTests.groovy
+++ b/src/test/groovy/io/sqreen/powerwaf/SchemaTests.groovy
@@ -72,7 +72,7 @@ class SchemaTests implements PowerwafTrait {
                         "address": "server.request.body"
                       }
                     ],
-                    "output": "server.request.body.schema"
+                    "output": "_dd.appsec.s.req.body"
                   }
                 ],
                 "scanners": [
@@ -149,7 +149,7 @@ class SchemaTests implements PowerwafTrait {
         Powerwaf.ResultWithData awd = ctx.runRules(data, limits, metrics)
         assertThat awd.derivatives, isA(Map)
 
-        def schema = new JsonSlurper().parseText(decodeGzipBase64(awd.derivatives['server.request.body.schema']))
+        def schema = new JsonSlurper().parseText(decodeGzipBase64(awd.derivatives['_dd.appsec.s.req.body']))
         assert deepSortLists(schema) == [
                 [
                  'a':[8],


### PR DESCRIPTION
Fix the parsing of the derivatives field from WAF responses. Currently there are two types of derivatives:
- `_dd.appsec.s.`: JSON value with the API schemas that should be gzipped and encoded in base64
- `_dd.appsec.fp.`: strings with the fingerpints

