### PR TITLE
Create metric: appsec.waf.input_truncated

### DIFF
--- a/src/main/java/io/sqreen/powerwaf/Additive.java
+++ b/src/main/java/io/sqreen/powerwaf/Additive.java
@@ -89,11 +89,11 @@ public final class Additive implements Closeable {
                 try {
                     try {
                         if (persistentData != null) {
-                            persistentBuffer = this.lease.serializeMore(limits, persistentData);
+                            persistentBuffer = this.lease.serializeMore(limits, persistentData, metrics);
                         }
                         if (ephemeralData != null) {
                             ephemeralLease = ByteBufferSerializer.getBlankLease();
-                            ephemeralBuffer = ephemeralLease.serializeMore(limits, ephemeralData);
+                            ephemeralBuffer = ephemeralLease.serializeMore(limits, ephemeralData, metrics);
                         }
                     } catch (Exception e) {
                         throw new UnclassifiedPowerwafException(
@@ -117,9 +117,7 @@ public final class Additive implements Closeable {
                     if (metrics != null) {
                         long after = System.nanoTime();
                         long totalTimeNs = after - before;
-                        synchronized (metrics) {
-                            metrics.totalRunTimeNs += totalTimeNs;
-                        }
+                        metrics.incrementTotalRunTimeNs(totalTimeNs);
                     }
                 }
                 return result;

--- a/src/main/java/io/sqreen/powerwaf/Additive.java
+++ b/src/main/java/io/sqreen/powerwaf/Additive.java
@@ -117,7 +117,9 @@ public final class Additive implements Closeable {
                     if (metrics != null) {
                         long after = System.nanoTime();
                         long totalTimeNs = after - before;
-                        metrics.incrementTotalRunTimeNs(totalTimeNs);
+                        synchronized (metrics) {
+                            metrics.totalRunTimeNs += totalTimeNs;
+                        }
                     }
                 }
                 return result;

--- a/src/main/java/io/sqreen/powerwaf/ByteBufferSerializer.java
+++ b/src/main/java/io/sqreen/powerwaf/ByteBufferSerializer.java
@@ -105,17 +105,19 @@ public class ByteBufferSerializer {
         // Integer.MAXVALUE
 
         if (remainingElements[0] < 0 || depthRemaining < 0) {
-            if (LOGGER.isDebugEnabled()) {
-                if (remainingElements[0] < 0) {
+            if (remainingElements[0] < 0) {
+                if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Ignoring element, for maxElements was exceeded");
-                    if (metrics != null) {
-                        metrics.incrementWafInputsTruncated(arena, InputTruncatedType.LIST_MAP_TOO_LARGE);
-                    }
-                } else if (depthRemaining <= 0) {
+                }
+                if (metrics != null) {
+                    metrics.incrementWafInputsTruncated(arena, InputTruncatedType.LIST_MAP_TOO_LARGE);
+                }
+            } else if (depthRemaining <= 0) {
+                if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Ignoring element, for maxDepth was exceeded");
-                    if (metrics != null) {
-                        metrics.incrementWafInputsTruncated(arena, InputTruncatedType.OBJECT_TOO_DEEP);
-                    }
+                }
+                if (metrics != null) {
+                    metrics.incrementWafInputsTruncated(arena, InputTruncatedType.OBJECT_TOO_DEEP);
                 }
             }
             // write empty map

--- a/src/main/java/io/sqreen/powerwaf/ByteBufferSerializer.java
+++ b/src/main/java/io/sqreen/powerwaf/ByteBufferSerializer.java
@@ -9,6 +9,8 @@
 package io.sqreen.powerwaf;
 
 import java.math.BigDecimal;
+
+import io.sqreen.powerwaf.metrics.InputTruncatedType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,14 +48,14 @@ public class ByteBufferSerializer {
         this.limits = limits;
     }
 
-    public ArenaLease serialize(Map<?, ?> map) {
+    public ArenaLease serialize(Map<?, ?> map, PowerwafMetrics metrics) {
         if (map == null) {
             throw new NullPointerException("map can't be null");
         }
 
         ArenaLease lease = ArenaPool.INSTANCE.getLease();
         try {
-            serializeMore(lease, this.limits, map);
+            serializeMore(lease, this.limits, map, metrics);
         } catch (RuntimeException | Error rte) {
             lease.close();
             throw rte;
@@ -66,7 +68,7 @@ public class ByteBufferSerializer {
         return ArenaPool.INSTANCE.getLease();
     }
 
-    private static ByteBuffer serializeMore(ArenaLease lease, Powerwaf.Limits limits, Map<?, ?> map) {
+    private static ByteBuffer serializeMore(ArenaLease lease, Powerwaf.Limits limits, Map<?, ?> map, PowerwafMetrics metrics) {
         Arena arena = lease.getArena();
         // limits apply per-serialization run
         int[] remainingElements = new int[]{limits.maxElements};
@@ -77,7 +79,7 @@ public class ByteBufferSerializer {
             throw new OutOfMemoryError();
         }
         PWArgsBuffer initialValue = pwArgsArrayBuffer.get(0);
-        doSerialize(arena, limits, initialValue, null, map, remainingElements, limits.maxDepth);
+        doSerialize(arena, limits, initialValue, null, map, remainingElements, limits.maxDepth, metrics);
         return initialValue.buffer;
 
         // if it threw somewhere, the arena will have elements that are never used
@@ -86,11 +88,14 @@ public class ByteBufferSerializer {
 
     private static void doSerialize(Arena arena, Powerwaf.Limits limits, PWArgsBuffer pwargsSlot,
                                     String parameterName, Object value, int[] remainingElements,
-                                    int depthRemaining) {
+                                    int depthRemaining, PowerwafMetrics metrics) {
         if (parameterName != null && parameterName.length() > limits.maxStringSize) {
             LOGGER.debug("Truncating parameter string from size {} to size {}",
                     parameterName.length(), limits.maxStringSize);
             parameterName = parameterName.substring(0, limits.maxStringSize);
+            if (metrics != null) {
+                metrics.incrementWafInputsTruncated(arena, InputTruncatedType.STRING_TOO_LONG);
+            }
         }
 
         remainingElements[0]--;
@@ -103,8 +108,14 @@ public class ByteBufferSerializer {
             if (LOGGER.isDebugEnabled()) {
                 if (remainingElements[0] < 0) {
                     LOGGER.debug("Ignoring element, for maxElements was exceeded");
+                    if (metrics != null) {
+                        metrics.incrementWafInputsTruncated(arena, InputTruncatedType.LIST_MAP_TOO_LARGE);
+                    }
                 } else if (depthRemaining <= 0) {
                     LOGGER.debug("Ignoring element, for maxDepth was exceeded");
+                    if (metrics != null) {
+                        metrics.incrementWafInputsTruncated(arena, InputTruncatedType.OBJECT_TOO_DEEP);
+                    }
                 }
             }
             // write empty map
@@ -124,6 +135,9 @@ public class ByteBufferSerializer {
                 LOGGER.debug("Truncating string from size {} to size {}",
                         svalue.length(), limits.maxStringSize);
                 svalue = svalue.subSequence(0, limits.maxStringSize);
+                if (metrics != null) {
+                    metrics.incrementWafInputsTruncated(arena, InputTruncatedType.STRING_TOO_LONG);
+                }
             }
             if (!pwargsSlot.writeString(arena, parameterName, svalue)) {
                 throw new RuntimeException("Could not write string");
@@ -144,13 +158,13 @@ public class ByteBufferSerializer {
             Iterator<?> iterator = ((Collection<?>) value).iterator();
             serializeIterable(
                     arena, limits, pwargsSlot, parameterName,
-                    remainingElements, depthRemaining, iterator, size);
+                    remainingElements, depthRemaining, metrics, iterator, size);
         } else if (value.getClass().isArray()) {
             int size = Math.min(Array.getLength(value), remainingElements[0]);
             Iterator<?> iterator = new GenericArrayIterator(value);
             serializeIterable(
                     arena, limits, pwargsSlot, parameterName, remainingElements,
-                    depthRemaining, iterator, size);
+                    depthRemaining, metrics, iterator, size);
         } else if (value instanceof Iterable) {
             // we need to iterate twice
             Iterator<?> iterator = ((Iterable<?>) value).iterator();
@@ -164,7 +178,7 @@ public class ByteBufferSerializer {
             iterator = ((Iterable<?>) value).iterator();
             serializeIterable(
                     arena, limits, pwargsSlot, parameterName,
-                    remainingElements, depthRemaining, iterator, size);
+                    remainingElements, depthRemaining, metrics, iterator, size);
         } else if (value instanceof Map) {
             int size = Math.min(((Map<?, ?>) value).size(), remainingElements[0]);
 
@@ -182,7 +196,7 @@ public class ByteBufferSerializer {
                     key = "";
                 }
                 doSerialize(arena, limits, newSlot, key.toString(), entry.getValue(),
-                        remainingElements, depthRemaining - 1);
+                        remainingElements, depthRemaining - 1, metrics);
             }
             if (i != size) {
                 throw new ConcurrentModificationException("i=" + i + ", size=" + size);
@@ -206,6 +220,7 @@ public class ByteBufferSerializer {
                                           String parameterName,
                                           int[] remainingElements,
                                           int depthRemaining,
+                                          PowerwafMetrics metrics,
                                           Iterator<?> iterator,
                                           int size) {
         PWArgsArrayBuffer pwArgsArrayBuffer = pwArgsSlot.writeArray(arena, parameterName, size);
@@ -217,14 +232,14 @@ public class ByteBufferSerializer {
         for (i = 0; iterator.hasNext() && i < size; i++) {
             Object newObj = iterator.next();
             PWArgsBuffer newSlot = pwArgsArrayBuffer.get(i);
-            doSerialize(arena, limits, newSlot, null, newObj, remainingElements, depthRemaining - 1);
+            doSerialize(arena, limits, newSlot, null, newObj, remainingElements, depthRemaining - 1, metrics);
         }
         if (i != size) {
             throw new ConcurrentModificationException("i=" + i + ", size=" + size);
         }
     }
 
-    private static class Arena {
+    protected static class Arena {
         private static final int MAX_BYTES_PER_CHAR_UTF8 =
                 (int) StandardCharsets.UTF_8.newEncoder().maxBytesPerChar();
 
@@ -407,8 +422,8 @@ public class ByteBufferSerializer {
             return this.arena.getFirstUsedPWArgsBuffer();
         }
 
-        public ByteBuffer serializeMore(Powerwaf.Limits limits, Map<?, ?> map) {
-            return ByteBufferSerializer.serializeMore(this, limits, map);
+        public ByteBuffer serializeMore(Powerwaf.Limits limits, Map<?, ?> map, PowerwafMetrics metrics) {
+            return ByteBufferSerializer.serializeMore(this, limits, map, metrics);
         }
 
         @Override

--- a/src/main/java/io/sqreen/powerwaf/ByteBufferSerializer.java
+++ b/src/main/java/io/sqreen/powerwaf/ByteBufferSerializer.java
@@ -248,7 +248,7 @@ public class ByteBufferSerializer {
         }
     }
 
-    protected static class Arena {
+    private static class Arena {
         private static final int MAX_BYTES_PER_CHAR_UTF8 =
                 (int) StandardCharsets.UTF_8.newEncoder().maxBytesPerChar();
 

--- a/src/main/java/io/sqreen/powerwaf/ByteBufferSerializer.java
+++ b/src/main/java/io/sqreen/powerwaf/ByteBufferSerializer.java
@@ -95,7 +95,7 @@ public class ByteBufferSerializer {
             parameterName = parameterName.substring(0, limits.maxStringSize);
             if (metrics != null) {
                 metrics.incrementWafInputsTruncatedCount(InputTruncatedType.STRING_TOO_LONG);
-                metrics.addWafInputsTruncatedSize(InputTruncatedType.STRING_TOO_LONG, parameterName.length());
+                // TODO - ADD METRIC FOR UNTRUNCATED SIZE
             }
         }
 
@@ -140,7 +140,7 @@ public class ByteBufferSerializer {
                 svalue = svalue.subSequence(0, limits.maxStringSize);
                 if (metrics != null) {
                     metrics.incrementWafInputsTruncatedCount(InputTruncatedType.STRING_TOO_LONG);
-                    metrics.addWafInputsTruncatedSize(InputTruncatedType.STRING_TOO_LONG, svalue.length());
+                    // TODO - ADD METRIC FOR UNTRUNCATED SIZE
                 }
             }
             if (!pwargsSlot.writeString(arena, parameterName, svalue)) {
@@ -159,10 +159,7 @@ public class ByteBufferSerializer {
         } else if (value instanceof Collection) {
             int size = Math.min(((Collection<?>) value).size(), remainingElements[0]);
 
-            int originalSize = ((Collection<?>) value).size();
-            if (metrics != null && remainingElements[0] < originalSize) {
-                metrics.addWafInputsTruncatedSize(InputTruncatedType.LIST_MAP_TOO_LARGE, originalSize);
-            }
+            // TODO - ADD METRIC FOR UNTRUNCATED SIZE
             Iterator<?> iterator = ((Collection<?>) value).iterator();
             serializeIterable(
                     arena, limits, pwargsSlot, parameterName,
@@ -170,10 +167,7 @@ public class ByteBufferSerializer {
         } else if (value.getClass().isArray()) {
             int size = Math.min(Array.getLength(value), remainingElements[0]);
 
-            int originalSize = Array.getLength(value);
-            if (metrics != null && remainingElements[0] < originalSize) {
-                metrics.addWafInputsTruncatedSize(InputTruncatedType.LIST_MAP_TOO_LARGE, originalSize);
-            }
+            // TODO - ADD METRIC FOR UNTRUNCATED SIZE
             Iterator<?> iterator = new GenericArrayIterator(value);
             serializeIterable(
                     arena, limits, pwargsSlot, parameterName, remainingElements,
@@ -188,6 +182,7 @@ public class ByteBufferSerializer {
                 size++;
             }
 
+            // TODO - ADD METRIC FOR UNTRUNCATED SIZE
             iterator = ((Iterable<?>) value).iterator();
             serializeIterable(
                     arena, limits, pwargsSlot, parameterName,
@@ -195,10 +190,7 @@ public class ByteBufferSerializer {
         } else if (value instanceof Map) {
             int size = Math.min(((Map<?, ?>) value).size(), remainingElements[0]);
 
-            int originalSize = ((Map<?, ?>) value).size();
-            if (metrics != null && remainingElements[0] < originalSize) {
-                metrics.addWafInputsTruncatedSize(InputTruncatedType.LIST_MAP_TOO_LARGE, originalSize);
-            }
+            // TODO - ADD METRIC FOR UNTRUNCATED SIZE
             PWArgsArrayBuffer pwArgsArrayBuffer = pwargsSlot.writeMap(arena, parameterName, size);
             if (pwArgsArrayBuffer == null) {
                 throw new RuntimeException("Could not write map");

--- a/src/main/java/io/sqreen/powerwaf/PowerwafContext.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafContext.java
@@ -133,7 +133,7 @@ public class PowerwafContext implements Closeable {
             long before = System.nanoTime();
             ByteBufferSerializer.ArenaLease lease;
             try {
-                lease = serializer.serialize(parameters);
+                lease = serializer.serialize(parameters, metrics);
             } catch (Exception e) {
                 throw new RuntimeException("Exception encoding parameters", e);
             }
@@ -154,9 +154,7 @@ public class PowerwafContext implements Closeable {
                 if (metrics != null) {
                     long after = System.nanoTime();
                     long totalTimeNs = after - before;
-                    synchronized (metrics) {
-                        metrics.totalRunTimeNs += totalTimeNs;
-                    }
+                    metrics.incrementTotalRunTimeNs(totalTimeNs);
                 }
             }
 

--- a/src/main/java/io/sqreen/powerwaf/PowerwafContext.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafContext.java
@@ -154,7 +154,9 @@ public class PowerwafContext implements Closeable {
                 if (metrics != null) {
                     long after = System.nanoTime();
                     long totalTimeNs = after - before;
-                    metrics.incrementTotalRunTimeNs(totalTimeNs);
+                    synchronized (metrics) {
+                        metrics.totalRunTimeNs += totalTimeNs;
+                    }
                 }
             }
 

--- a/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
@@ -10,9 +10,7 @@ package io.sqreen.powerwaf;
 
 import io.sqreen.powerwaf.metrics.InputTruncatedType;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -21,11 +19,9 @@ public class PowerwafMetrics {
     volatile long totalRunTimeNs;
     volatile long totalDdwafRunTimeNs;
     volatile Map<InputTruncatedType, AtomicLong> wafInputsTruncatedCount;
-    volatile Map<InputTruncatedType, List<Long>> wafInputsTruncatedSize;
 
     PowerwafMetrics() {
         this.wafInputsTruncatedCount = new HashMap<>();
-        this.wafInputsTruncatedSize = new HashMap<>();
     }
 
     public long getTotalRunTimeNs() {
@@ -53,20 +49,7 @@ public class PowerwafMetrics {
     }
 
     protected void incrementWafInputsTruncatedCount(InputTruncatedType type) {
-        synchronized (this) {
-            wafInputsTruncatedCount.putIfAbsent(type, new AtomicLong(0));
-            wafInputsTruncatedCount.get(type).incrementAndGet();
-        }
-    }
-
-    public List<Long> getWafInputsTruncatedSize(InputTruncatedType type) {
-        return wafInputsTruncatedSize.get(type) == null ? new ArrayList<>() : wafInputsTruncatedSize.get(type);
-    }
-
-    protected void addWafInputsTruncatedSize(InputTruncatedType type, long size) {
-        synchronized (this) {
-            wafInputsTruncatedSize.putIfAbsent(type, new ArrayList<>());
-            wafInputsTruncatedSize.get(type).add(size);
-        }
+        wafInputsTruncatedCount.putIfAbsent(type, new AtomicLong(0));
+        wafInputsTruncatedCount.get(type).incrementAndGet();
     }
 }

--- a/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
@@ -28,20 +28,8 @@ public class PowerwafMetrics {
         return totalRunTimeNs;
     }
 
-    protected void incrementTotalRunTimeNs(long increment) {
-        synchronized (this) {
-            totalRunTimeNs += increment;
-        }
-    }
-
     public long getTotalDdwafRunTimeNs() {
         return totalDdwafRunTimeNs;
-    }
-
-    protected void incrementTotalDdwafRunTimeNs(long increment) {
-        synchronized (this) {
-            totalDdwafRunTimeNs += increment;
-        }
     }
 
     public Long getWafInputsTruncatedCount(InputTruncatedType type) {

--- a/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
@@ -16,9 +16,9 @@ public class PowerwafMetrics {
     // total accumulated time between runs, including metrics
     volatile long totalRunTimeNs;
     volatile long totalDdwafRunTimeNs;
-    volatile AtomicLong wafInputsTruncatedStringTooLongCount = new AtomicLong();
-    volatile AtomicLong wafInputsTruncatedListMapTooLargeCount = new AtomicLong();
-    volatile AtomicLong wafInputsTruncatedObjectTooDeepCount = new AtomicLong();
+    AtomicLong wafInputsTruncatedStringTooLongCount = new AtomicLong();
+    AtomicLong wafInputsTruncatedListMapTooLargeCount = new AtomicLong();
+    AtomicLong wafInputsTruncatedObjectTooDeepCount = new AtomicLong();
 
     PowerwafMetrics() {
     }

--- a/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
@@ -8,18 +8,56 @@
 
 package io.sqreen.powerwaf;
 
+import io.sqreen.powerwaf.metrics.InputTruncatedType;
+
+import java.util.HashMap;
+import java.util.Map;
+
 public class PowerwafMetrics {
     // total accumulated time between runs, including metrics
     volatile long totalRunTimeNs;
     volatile long totalDdwafRunTimeNs;
+    volatile Map<ByteBufferSerializer.Arena, Map<InputTruncatedType, Long>> wafInputsTruncated;
 
-    PowerwafMetrics() { }
+    PowerwafMetrics() {
+        this.wafInputsTruncated = new HashMap<>();
+    }
 
     public long getTotalRunTimeNs() {
         return totalRunTimeNs;
     }
 
+    protected void incrementTotalRunTimeNs(long increment) {
+        synchronized (this) {
+            totalRunTimeNs += increment;
+        }
+    }
+
     public long getTotalDdwafRunTimeNs() {
         return totalDdwafRunTimeNs;
+    }
+
+    protected void incrementTotalDdwafRunTimeNs(long increment) {
+        synchronized (this) {
+            totalDdwafRunTimeNs += increment;
+        }
+    }
+
+    public Map<InputTruncatedType, Long> getWafInputsTruncated() {
+        Map<InputTruncatedType, Long> result = new HashMap<>();
+        // Flatten the maps of arenas
+        synchronized (this) {
+            for (Map.Entry<ByteBufferSerializer.Arena, Map<InputTruncatedType, Long>> entry : wafInputsTruncated.entrySet()) {
+                result.putAll(entry.getValue());
+            }
+        }
+        return result;
+    }
+
+    protected void incrementWafInputsTruncated(ByteBufferSerializer.Arena arena, InputTruncatedType type) {
+        synchronized (this) {
+            wafInputsTruncated.putIfAbsent(arena, new HashMap<>());
+            wafInputsTruncated.get(arena).put(type, wafInputsTruncated.get(arena).getOrDefault(type, 0L) + 1);
+        }
     }
 }

--- a/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
@@ -57,6 +57,9 @@ public class PowerwafMetrics {
     protected void incrementWafInputsTruncated(ByteBufferSerializer.Arena arena, InputTruncatedType type) {
         synchronized (this) {
             wafInputsTruncated.putIfAbsent(arena, new HashMap<>());
+            if ((type.equals(InputTruncatedType.LIST_MAP_TOO_LARGE) || type.equals(InputTruncatedType.OBJECT_TOO_DEEP)) && wafInputsTruncated.get(arena).containsKey(type)) {
+                return;
+            }
             wafInputsTruncated.get(arena).put(type, wafInputsTruncated.get(arena).getOrDefault(type, 0L) + 1);
         }
     }

--- a/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
@@ -10,18 +10,17 @@ package io.sqreen.powerwaf;
 
 import io.sqreen.powerwaf.metrics.InputTruncatedType;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class PowerwafMetrics {
     // total accumulated time between runs, including metrics
     volatile long totalRunTimeNs;
     volatile long totalDdwafRunTimeNs;
-    volatile Map<InputTruncatedType, AtomicLong> wafInputsTruncatedCount;
+    volatile AtomicLong wafInputsTruncatedStringTooLongCount = new AtomicLong();
+    volatile AtomicLong wafInputsTruncatedListMapTooLargeCount = new AtomicLong();
+    volatile AtomicLong wafInputsTruncatedObjectTooDeepCount = new AtomicLong();
 
     PowerwafMetrics() {
-        this.wafInputsTruncatedCount = new HashMap<>();
     }
 
     public long getTotalRunTimeNs() {
@@ -32,12 +31,32 @@ public class PowerwafMetrics {
         return totalDdwafRunTimeNs;
     }
 
-    public Long getWafInputsTruncatedCount(InputTruncatedType type) {
-        return wafInputsTruncatedCount.get(type) == null ? 0 : wafInputsTruncatedCount.get(type).get();
+    public long getWafInputsTruncatedCount(InputTruncatedType type) {
+        switch (type) {
+            case STRING_TOO_LONG:
+                return wafInputsTruncatedStringTooLongCount.get();
+            case LIST_MAP_TOO_LARGE:
+                return wafInputsTruncatedListMapTooLargeCount.get();
+            case OBJECT_TOO_DEEP:
+                return wafInputsTruncatedObjectTooDeepCount.get();
+            default:
+                return 0L;
+        }
     }
 
     protected void incrementWafInputsTruncatedCount(InputTruncatedType type) {
-        wafInputsTruncatedCount.putIfAbsent(type, new AtomicLong(0));
-        wafInputsTruncatedCount.get(type).incrementAndGet();
+        switch (type) {
+            case STRING_TOO_LONG:
+                wafInputsTruncatedStringTooLongCount.incrementAndGet();
+                return;
+            case LIST_MAP_TOO_LARGE:
+                wafInputsTruncatedListMapTooLargeCount.incrementAndGet();
+                return;
+            case OBJECT_TOO_DEEP:
+                wafInputsTruncatedObjectTooDeepCount.incrementAndGet();
+                return;
+            default:
+                return;
+        }
     }
 }

--- a/src/main/java/io/sqreen/powerwaf/metrics/InputTruncatedType.java
+++ b/src/main/java/io/sqreen/powerwaf/metrics/InputTruncatedType.java
@@ -1,0 +1,17 @@
+package io.sqreen.powerwaf.metrics;
+
+public enum InputTruncatedType {
+    STRING_TOO_LONG(1),
+    LIST_MAP_TOO_LARGE(2),
+    OBJECT_TOO_DEEP(4);
+
+    private final int value;
+
+    InputTruncatedType(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/src/test/groovy/io/sqreen/powerwaf/ByteBufferSerializerTests.groovy
+++ b/src/test/groovy/io/sqreen/powerwaf/ByteBufferSerializerTests.groovy
@@ -382,7 +382,7 @@ class ByteBufferSerializerTests implements PowerwafTrait {
         s.stripIndent()[1..-1]
     }
 
-    private assertMetrics(Long countStringTooLong, Long countListMapTooLarge, Long countObjectTooDeep) {
+    private void assertMetrics(Long countStringTooLong, Long countListMapTooLarge, Long countObjectTooDeep) {
         assertThat(metrics.getWafInputsTruncatedCount(InputTruncatedType.STRING_TOO_LONG), is(countStringTooLong))
         assertThat(metrics.getWafInputsTruncatedCount(InputTruncatedType.LIST_MAP_TOO_LARGE), is(countListMapTooLarge))
         assertThat(metrics.getWafInputsTruncatedCount(InputTruncatedType.OBJECT_TOO_DEEP), is(countObjectTooDeep))

--- a/src/test/groovy/io/sqreen/powerwaf/InvalidInvocationTests.groovy
+++ b/src/test/groovy/io/sqreen/powerwaf/InvalidInvocationTests.groovy
@@ -96,7 +96,7 @@ class InvalidInvocationTests implements ReactiveTrait {
         additive = ctx.openAdditive()
 
         ByteBufferSerializer serializer = new ByteBufferSerializer(limits)
-        serializer.serialize([a: 'b']).withCloseable { lease ->
+        serializer.serialize([a: 'b'], metrics).withCloseable { lease ->
             ByteBuffer buffer = lease.firstPWArgsByteBuffer
             def slice = buffer.slice()
             slice.position(ByteBufferSerializer.SIZEOF_PWARGS)


### PR DESCRIPTION
# Motivation
The main goal of this PR is to improve our observability by including a new type of metric:
- **appsec.waf.input_truncated**: Number of inputs truncated
  - _truncation_reason_: Byte with the truncation type
  
# Additional Information
The metric **appsec.waf.truncated_value_size** won't be implemented but some comments will be put in the places where must be added in the future. The main reason is due to the fact that currently distribution metrics are not supported.

Jira ticket: [APPSEC-56479](https://datadoghq.atlassian.net/browse/APPSEC-56479)

[APPSEC-56479]: https://datadoghq.atlassian.net/browse/APPSEC-56479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ