### PR TITLE
Refactor metrics: totalRunTimeNs & totalDdwafRunTimeNs

### DIFF
--- a/src/main/c/metrics.c
+++ b/src/main/c/metrics.c
@@ -57,13 +57,16 @@ error:
 void metrics_update_checked(JNIEnv *env, jobject metrics_obj, jlong run_time_ns,
                             jlong ddwaf_run_time_ns)
 {
+    jobject rt_obj = NULL;
+    jobject ddrt_obj = NULL;
+
     if (JNI(MonitorEnter, metrics_obj) < 0) {
         JNI(ThrowNew, jcls_rte, "Error entering monitor on the metrics object");
         goto error;
     }
 
     if (run_time_ns > 0) {
-        jobject rt_obj = JNI(GetObjectField, metrics_obj, _total_run_time_ns_field);
+        rt_obj = JNI(GetObjectField, metrics_obj, _total_run_time_ns_field);
         if (JNI(ExceptionCheck)) {
             goto error;
         }
@@ -71,10 +74,9 @@ void metrics_update_checked(JNIEnv *env, jobject metrics_obj, jlong run_time_ns,
         if (JNI(ExceptionCheck)) {
             goto error;
         }
-        JNI(DeleteLocalRef, rt_obj);
     }
 
-    jobject ddrt_obj = JNI(GetObjectField, metrics_obj, _total_ddwaf_run_time_ns_field);
+    ddrt_obj = JNI(GetObjectField, metrics_obj, _total_ddwaf_run_time_ns_field);
     if (JNI(ExceptionCheck)) {
         goto error;
     }
@@ -83,7 +85,12 @@ void metrics_update_checked(JNIEnv *env, jobject metrics_obj, jlong run_time_ns,
         goto error;
     }
 
-    JNI(DeleteLocalRef, ddrt_obj);
 error:
+    if (rt_obj) {
+        JNI(DeleteLocalRef, rt_obj);
+    }
+    if (ddrt_obj) {
+        JNI(DeleteLocalRef, ddrt_obj);
+    }
     JNI(MonitorExit, metrics_obj);
 }

--- a/src/main/c/metrics.c
+++ b/src/main/c/metrics.c
@@ -68,6 +68,10 @@ void metrics_update_checked(JNIEnv *env, jobject metrics_obj, jlong run_time_ns,
             goto error;
         }
         JNI(CallLongMethod, rt_obj, _add_and_get, run_time_ns);
+        if (JNI(ExceptionCheck)) {
+            goto error;
+        }
+        JNI(DeleteLocalRef, rt_obj);
     }
 
     jobject ddrt_obj = JNI(GetObjectField, metrics_obj, _total_ddwaf_run_time_ns_field);
@@ -79,6 +83,9 @@ void metrics_update_checked(JNIEnv *env, jobject metrics_obj, jlong run_time_ns,
         goto error;
     }
 
+    JNI(DeleteLocalRef, ddrt_obj);
 error:
     JNI(MonitorExit, metrics_obj);
+    JNI(DeleteLocalRef, rt_obj);
+    JNI(DeleteLocalRef, ddrt_obj);
 }

--- a/src/main/c/metrics.c
+++ b/src/main/c/metrics.c
@@ -86,6 +86,5 @@ void metrics_update_checked(JNIEnv *env, jobject metrics_obj, jlong run_time_ns,
     JNI(DeleteLocalRef, ddrt_obj);
 error:
     JNI(MonitorExit, metrics_obj);
-    JNI(DeleteLocalRef, rt_obj);
     JNI(DeleteLocalRef, ddrt_obj);
 }

--- a/src/main/c/metrics.c
+++ b/src/main/c/metrics.c
@@ -86,5 +86,4 @@ void metrics_update_checked(JNIEnv *env, jobject metrics_obj, jlong run_time_ns,
     JNI(DeleteLocalRef, ddrt_obj);
 error:
     JNI(MonitorExit, metrics_obj);
-    JNI(DeleteLocalRef, ddrt_obj);
 }

--- a/src/main/java/io/sqreen/powerwaf/Additive.java
+++ b/src/main/java/io/sqreen/powerwaf/Additive.java
@@ -117,9 +117,7 @@ public final class Additive implements Closeable {
                     if (metrics != null) {
                         long after = System.nanoTime();
                         long totalTimeNs = after - before;
-                        synchronized (metrics) {
-                            metrics.totalRunTimeNs += totalTimeNs;
-                        }
+                        metrics.addTotalRunTimeNs(totalTimeNs);
                     }
                 }
                 return result;

--- a/src/main/java/io/sqreen/powerwaf/PowerwafContext.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafContext.java
@@ -154,9 +154,7 @@ public class PowerwafContext implements Closeable {
                 if (metrics != null) {
                     long after = System.nanoTime();
                     long totalTimeNs = after - before;
-                    synchronized (metrics) {
-                        metrics.totalRunTimeNs += totalTimeNs;
-                    }
+                    metrics.addTotalRunTimeNs(totalTimeNs);
                 }
             }
 

--- a/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
@@ -12,8 +12,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class PowerwafMetrics {
     // total accumulated time between runs, including metrics
-    volatile AtomicLong totalRunTimeNs = new AtomicLong();
-    volatile AtomicLong totalDdwafRunTimeNs = new AtomicLong();
+    AtomicLong totalRunTimeNs = new AtomicLong();
+    AtomicLong totalDdwafRunTimeNs = new AtomicLong();
 
     PowerwafMetrics() {
     }

--- a/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
@@ -8,18 +8,31 @@
 
 package io.sqreen.powerwaf;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 public class PowerwafMetrics {
     // total accumulated time between runs, including metrics
-    volatile long totalRunTimeNs;
-    volatile long totalDdwafRunTimeNs;
+    volatile AtomicLong totalRunTimeNs;
+    volatile AtomicLong totalDdwafRunTimeNs;
 
-    PowerwafMetrics() { }
+    PowerwafMetrics() {
+        totalRunTimeNs = new AtomicLong();
+        totalDdwafRunTimeNs = new AtomicLong();
+    }
 
     public long getTotalRunTimeNs() {
-        return totalRunTimeNs;
+        return totalRunTimeNs.get();
+    }
+
+    protected void addTotalRunTimeNs(long increment) {
+        totalRunTimeNs.addAndGet(increment);
     }
 
     public long getTotalDdwafRunTimeNs() {
-        return totalDdwafRunTimeNs;
+        return totalRunTimeNs.get();
+    }
+
+    protected void addTotalDdwafRunTimeNs(long increment) {
+        totalDdwafRunTimeNs.addAndGet(increment);
     }
 }

--- a/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
@@ -29,8 +29,4 @@ public class PowerwafMetrics {
     public long getTotalDdwafRunTimeNs() {
         return totalRunTimeNs.get();
     }
-
-    protected void addTotalDdwafRunTimeNs(long increment) {
-        totalDdwafRunTimeNs.addAndGet(increment);
-    }
 }

--- a/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
+++ b/src/main/java/io/sqreen/powerwaf/PowerwafMetrics.java
@@ -12,12 +12,10 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class PowerwafMetrics {
     // total accumulated time between runs, including metrics
-    volatile AtomicLong totalRunTimeNs;
-    volatile AtomicLong totalDdwafRunTimeNs;
+    volatile AtomicLong totalRunTimeNs = new AtomicLong();
+    volatile AtomicLong totalDdwafRunTimeNs = new AtomicLong();
 
     PowerwafMetrics() {
-        totalRunTimeNs = new AtomicLong();
-        totalDdwafRunTimeNs = new AtomicLong();
     }
 
     public long getTotalRunTimeNs() {


### PR DESCRIPTION
# Motivation
With this PR we want to refactor current metrics **totalRunTimeNs** and **totalDdwafRunTimeNs** to use **AtomicLong** class instead of **Long**. This will avoid the use of **synchronized** block.

# Additional Information
Jira ticket [APPSEC-56479](https://datadoghq.atlassian.net/browse/APPSEC-56479)

[APPSEC-56479]: https://datadoghq.atlassian.net/browse/APPSEC-56479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ