### PR TITLE
Allow publishing to maven local

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,12 @@ You can run tests with ASAN with the `withASAN` property:
 ./gradlew check -PwithASAN
 ```
 
+#### Local testing
+
+To deploy the current bindings to your local Maven repository, use the following command:
+
+```sh
+./gradlew publishToMavenLocal
+```
+
+This will publish the artifact with the `-SNAPSHOT` suffix, allowing for convenient local testing.

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ plugins {
     id 'groovy'
     id 'jacoco'
     id 'ivy-publish'
+    id 'maven-publish'
     id 'codenarc'
     id 'me.champeau.jmh' version '0.7.2'
     id 'info.solidsoft.pitest' version '1.15.0'
@@ -328,6 +329,12 @@ publishing {
                 text = description
             }
         }
+
+        // only publish to maven local for now
+        maven(MavenPublication) {
+            version = "${project.version}-SNAPSHOT"
+            from components.java
+        }
     }
 }
 
@@ -502,6 +509,10 @@ pitest {
 
 tasks.named("pitest").configure {
     dependsOn buildNativeLibDebug
+}
+
+project.afterEvaluate {
+    tasks.withType(PublishToMavenRepository).each { it.enabled = false }
 }
 
 // vim: set et ts=4 sw=4 list:


### PR DESCRIPTION
This update integrates the `maven-publish` plugin, allowing the artifact to be published to the local Maven repository. The artifact will be published with a `-SNAPSHOT` suffix based on the version specified in the `build.gradle` script.

To publish to Maven local, use:

```sh
./gradlew publishToMavenLocal
```