### PR TITLE
Fix error codes

### DIFF
--- a/src/main/java/com/datadog/ddwaf/exception/AbstractWafException.java
+++ b/src/main/java/com/datadog/ddwaf/exception/AbstractWafException.java
@@ -24,11 +24,11 @@ public abstract class AbstractWafException extends Exception {
     public static AbstractWafException createFromErrorCode(int errorCode) {
         switch (errorCode) {
             case -1:
-                return new InvalidArgumentWafException();
+                return new InvalidArgumentWafException(errorCode);
             case -2:
-                return new InvalidObjectWafException();
+                return new InvalidObjectWafException(errorCode);
             case -3:
-                return new InternalWafException();
+                return new InternalWafException(errorCode);
             default:
                 return new UnclassifiedWafException(errorCode);
         }

--- a/src/main/java/com/datadog/ddwaf/exception/InternalWafException.java
+++ b/src/main/java/com/datadog/ddwaf/exception/InternalWafException.java
@@ -9,7 +9,7 @@
 package com.datadog.ddwaf.exception;
 
 public class InternalWafException extends AbstractWafException {
-    public InternalWafException() {
-        super("Internal error", -3);
+    public InternalWafException(int errorCode) {
+        super("Internal error", errorCode);
     }
 }

--- a/src/main/java/com/datadog/ddwaf/exception/InternalWafException.java
+++ b/src/main/java/com/datadog/ddwaf/exception/InternalWafException.java
@@ -10,6 +10,6 @@ package com.datadog.ddwaf.exception;
 
 public class InternalWafException extends AbstractWafException {
     public InternalWafException() {
-        super("Internal error", -4);
+        super("Internal error", -3);
     }
 }

--- a/src/main/java/com/datadog/ddwaf/exception/InvalidArgumentWafException.java
+++ b/src/main/java/com/datadog/ddwaf/exception/InvalidArgumentWafException.java
@@ -10,6 +10,6 @@ package com.datadog.ddwaf.exception;
 
 public class InvalidArgumentWafException extends AbstractWafException {
     public InvalidArgumentWafException() {
-        super("Invalid argument", -2);
+        super("Invalid argument", -1);
     }
 }

--- a/src/main/java/com/datadog/ddwaf/exception/InvalidArgumentWafException.java
+++ b/src/main/java/com/datadog/ddwaf/exception/InvalidArgumentWafException.java
@@ -9,7 +9,7 @@
 package com.datadog.ddwaf.exception;
 
 public class InvalidArgumentWafException extends AbstractWafException {
-    public InvalidArgumentWafException() {
-        super("Invalid argument", -1);
+    public InvalidArgumentWafException(int errorCode) {
+        super("Invalid argument", errorCode);
     }
 }

--- a/src/main/java/com/datadog/ddwaf/exception/InvalidObjectWafException.java
+++ b/src/main/java/com/datadog/ddwaf/exception/InvalidObjectWafException.java
@@ -9,7 +9,7 @@
 package com.datadog.ddwaf.exception;
 
 public class InvalidObjectWafException extends AbstractWafException {
-    public InvalidObjectWafException() {
-        super("Invalid object", -2);
+    public InvalidObjectWafException(int errorCode) {
+        super("Invalid object", errorCode);
     }
 }

--- a/src/main/java/com/datadog/ddwaf/exception/InvalidObjectWafException.java
+++ b/src/main/java/com/datadog/ddwaf/exception/InvalidObjectWafException.java
@@ -10,6 +10,6 @@ package com.datadog.ddwaf.exception;
 
 public class InvalidObjectWafException extends AbstractWafException {
     public InvalidObjectWafException() {
-        super("Invalid object", -3);
+        super("Invalid object", -2);
     }
 }

--- a/src/main/java/com/datadog/ddwaf/exception/UnclassifiedWafException.java
+++ b/src/main/java/com/datadog/ddwaf/exception/UnclassifiedWafException.java
@@ -9,16 +9,19 @@
 package com.datadog.ddwaf.exception;
 
 public class UnclassifiedWafException extends AbstractWafException {
+
+    private static final int code = -127;
+
     public UnclassifiedWafException(int errorCode) {
-        super("Unclassified Waf exception with error code " + errorCode, errorCode);
+        super("Unclassified Waf exception with error code " + errorCode, code);
     }
 
     public UnclassifiedWafException(String message) {
-        super(message, Integer.MIN_VALUE);
+        super(message, code);
     }
 
     public UnclassifiedWafException(String message, Throwable cause) {
-        super(message, Integer.MIN_VALUE, cause);
+        super(message, code, cause);
     }
 
     public UnclassifiedWafException(Throwable e) {

--- a/src/main/java/com/datadog/ddwaf/exception/UnclassifiedWafException.java
+++ b/src/main/java/com/datadog/ddwaf/exception/UnclassifiedWafException.java
@@ -13,7 +13,7 @@ public class UnclassifiedWafException extends AbstractWafException {
     private static final int code = -127;
 
     public UnclassifiedWafException(int errorCode) {
-        super("Unclassified Waf exception with error code " + errorCode, code);
+        super("Unclassified Waf exception with error code " + errorCode, errorCode);
     }
 
     public UnclassifiedWafException(String message) {


### PR DESCRIPTION
Update the error codes used in various exception classes in the `com.datadog.ddwaf.exception` package to ensure consistency with the [RFC](https://docs.google.com/document/d/1D4hkC0jwwUyeo0hEQgyKP54kM1LZU98GL8MaP60tQrA/edit?pli=1&tab=t.0#heading=h.giuqiiuf9z6q)

Allowed error codes are -1, -2, -3 and -127