### PR TITLE
Improve error handling in WAF callbacks

### DIFF
--- a/src/main/java/com/datadog/ddwaf/WafErrorCode.java
+++ b/src/main/java/com/datadog/ddwaf/WafErrorCode.java
@@ -1,0 +1,41 @@
+package com.datadog.ddwaf;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public enum WafErrorCode {
+    INVALID_ARGUMENT(-1),
+    INVALID_OBJECT(-2),
+    INTERNAL_ERROR(-3),
+    BINDING_ERROR(-127); // This is a special error code that is not returned by the WAF, is used to signal a binding error
+
+    private final int code;
+
+    private static final Map<Integer, WafErrorCode> CODE_MAP;
+
+    static {
+        Map<Integer, WafErrorCode> map = new HashMap<>();
+        for (WafErrorCode errorCode : values()) {
+            map.put(errorCode.code, errorCode);
+        }
+        CODE_MAP = Collections.unmodifiableMap(map);
+    }
+
+    WafErrorCode(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public static WafErrorCode fromCode(int code) {
+        return CODE_MAP.get(code);
+    }
+
+    public static Map<Integer, WafErrorCode> getDefinedCodes() {
+        return CODE_MAP;
+    }
+}
+

--- a/src/main/java/com/datadog/ddwaf/exception/AbstractWafException.java
+++ b/src/main/java/com/datadog/ddwaf/exception/AbstractWafException.java
@@ -8,6 +8,8 @@
 
 package com.datadog.ddwaf.exception;
 
+import com.datadog.ddwaf.WafErrorCode;
+
 public abstract class AbstractWafException extends Exception {
     public final int code;
 
@@ -22,15 +24,23 @@ public abstract class AbstractWafException extends Exception {
     }
 
     public static AbstractWafException createFromErrorCode(int errorCode) {
-        switch (errorCode) {
-            case -1:
-                return new InvalidArgumentWafException(errorCode);
-            case -2:
-                return new InvalidObjectWafException(errorCode);
-            case -3:
-                return new InternalWafException(errorCode);
-            default:
-                return new UnclassifiedWafException(errorCode);
+        WafErrorCode wafErrorCode = WafErrorCode.fromCode(errorCode);
+
+        // If the error code is not defined in the enum, return a generic exception
+        if (wafErrorCode == null) {
+            return new UnclassifiedWafException(errorCode);
         }
+
+        switch (wafErrorCode) {
+            case INVALID_ARGUMENT:
+                return new InvalidArgumentWafException(errorCode);
+            case INVALID_OBJECT:
+                return new InvalidObjectWafException(errorCode);
+            case INTERNAL_ERROR:
+                return new InternalWafException(errorCode);
+        }
+
+        // This point should never be reached unless a new enum value is added and not handled above
+        throw new IllegalStateException("Unhandled WafErrorCode: " + wafErrorCode);
     }
 }

--- a/src/main/java/com/datadog/ddwaf/exception/UnclassifiedWafException.java
+++ b/src/main/java/com/datadog/ddwaf/exception/UnclassifiedWafException.java
@@ -8,20 +8,20 @@
 
 package com.datadog.ddwaf.exception;
 
-public class UnclassifiedWafException extends AbstractWafException {
+import com.datadog.ddwaf.WafErrorCode;
 
-    private static final int code = -127;
+public class UnclassifiedWafException extends AbstractWafException {
 
     public UnclassifiedWafException(int errorCode) {
         super("Unclassified Waf exception with error code " + errorCode, errorCode);
     }
 
     public UnclassifiedWafException(String message) {
-        super(message, code);
+        super(message, WafErrorCode.BINDING_ERROR.getCode());
     }
 
     public UnclassifiedWafException(String message, Throwable cause) {
-        super(message, code, cause);
+        super(message, WafErrorCode.BINDING_ERROR.getCode(), cause);
     }
 
     public UnclassifiedWafException(Throwable e) {

--- a/src/test/groovy/com/datadog/ddwaf/WafErrorCodeTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/WafErrorCodeTest.groovy
@@ -1,7 +1,6 @@
 package com.datadog.ddwaf
 
 import org.junit.Test
-import static org.junit.Assert.assertNull
 
 class WafErrorCodeTest {
 
@@ -19,13 +18,12 @@ class WafErrorCodeTest {
         assert WafErrorCode.fromCode(-2) == WafErrorCode.INVALID_OBJECT
         assert WafErrorCode.fromCode(-3) == WafErrorCode.INTERNAL_ERROR
         assert WafErrorCode.fromCode(-127) == WafErrorCode.BINDING_ERROR
-        assertNull(WafErrorCode.fromCode(999)) // Unknown code should return null
+        assert WafErrorCode.fromCode(999) == null // Unknown code should return null
     }
 
     @Test
     void testDefinedCodesMap() {
-        def codes = WafErrorCode.getDefinedCodes()
-
+        Map<Integer, WafErrorCode> codes = WafErrorCode.definedCodes
         assert codes.size() == 4
         assert codes[-1] == WafErrorCode.INVALID_ARGUMENT
         assert codes[-2] == WafErrorCode.INVALID_OBJECT
@@ -33,4 +31,4 @@ class WafErrorCodeTest {
         assert codes[-127] == WafErrorCode.BINDING_ERROR
         assert codes instanceof java.util.Collections.UnmodifiableMap
     }
-} 
+}

--- a/src/test/groovy/com/datadog/ddwaf/WafErrorCodeTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/WafErrorCodeTest.groovy
@@ -24,13 +24,12 @@ class WafErrorCodeTest {
     @Test
     void testDefinedCodesMap() {
         // codenarc-disable UnnecessaryGetter
-        Map<Integer, WafErrorCode> codes = WafErrorCode.getDefinedCodes()
+        def codes = WafErrorCode.getDefinedCodes()
         // codenarc-enable UnnecessaryGetter
         assert codes.size() == 4
         assert codes[-1] == WafErrorCode.INVALID_ARGUMENT
         assert codes[-2] == WafErrorCode.INVALID_OBJECT
         assert codes[-3] == WafErrorCode.INTERNAL_ERROR
         assert codes[-127] == WafErrorCode.BINDING_ERROR
-        assert codes instanceof java.util.Collections.UnmodifiableMap
     }
 }

--- a/src/test/groovy/com/datadog/ddwaf/WafErrorCodeTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/WafErrorCodeTest.groovy
@@ -23,7 +23,9 @@ class WafErrorCodeTest {
 
     @Test
     void testDefinedCodesMap() {
-        Map<Integer, WafErrorCode> codes = WafErrorCode.definedCodes
+        // codenarc-disable UnnecessaryGetter
+        Map<Integer, WafErrorCode> codes = WafErrorCode.getDefinedCodes()
+        // codenarc-enable UnnecessaryGetter
         assert codes.size() == 4
         assert codes[-1] == WafErrorCode.INVALID_ARGUMENT
         assert codes[-2] == WafErrorCode.INVALID_OBJECT

--- a/src/test/groovy/com/datadog/ddwaf/WafErrorCodeTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/WafErrorCodeTest.groovy
@@ -1,0 +1,36 @@
+package com.datadog.ddwaf
+
+import org.junit.Test
+import static org.junit.Assert.assertNull
+
+class WafErrorCodeTest {
+
+    @Test
+    void testCorrectCodeForEachErrorCode() {
+        assert WafErrorCode.INVALID_ARGUMENT.code == -1
+        assert WafErrorCode.INVALID_OBJECT.code == -2
+        assert WafErrorCode.INTERNAL_ERROR.code == -3
+        assert WafErrorCode.BINDING_ERROR.code == -127
+    }
+
+    @Test
+    void testCorrectWafErrorCodeFromCode() {
+        assert WafErrorCode.fromCode(-1) == WafErrorCode.INVALID_ARGUMENT
+        assert WafErrorCode.fromCode(-2) == WafErrorCode.INVALID_OBJECT
+        assert WafErrorCode.fromCode(-3) == WafErrorCode.INTERNAL_ERROR
+        assert WafErrorCode.fromCode(-127) == WafErrorCode.BINDING_ERROR
+        assertNull(WafErrorCode.fromCode(999)) // Unknown code should return null
+    }
+
+    @Test
+    void testDefinedCodesMap() {
+        def codes = WafErrorCode.getDefinedCodes()
+
+        assert codes.size() == 4
+        assert codes[-1] == WafErrorCode.INVALID_ARGUMENT
+        assert codes[-2] == WafErrorCode.INVALID_OBJECT
+        assert codes[-3] == WafErrorCode.INTERNAL_ERROR
+        assert codes[-127] == WafErrorCode.BINDING_ERROR
+        assert codes instanceof java.util.Collections.UnmodifiableMap
+    }
+} 

--- a/src/test/groovy/com/datadog/ddwaf/exception/AbstractWafExceptionTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/exception/AbstractWafExceptionTest.groovy
@@ -24,18 +24,17 @@ class AbstractWafExceptionTest {
 
     @Test
     void testSetCorrectMessageInCreatedExceptions() {
-        assert AbstractWafException.createFromErrorCode(-1).message == "Invalid argument"
-        assert AbstractWafException.createFromErrorCode(-2).message == "Invalid object"
-        assert AbstractWafException.createFromErrorCode(-3).message == "Internal error"
-        assert AbstractWafException.createFromErrorCode(999).message == "Unknown error code: 999"
+        assert AbstractWafException.createFromErrorCode(-1).message == 'Invalid argument'
+        assert AbstractWafException.createFromErrorCode(-2).message == 'Invalid object'
+        assert AbstractWafException.createFromErrorCode(-3).message == 'Internal error'
+        assert AbstractWafException.createFromErrorCode(999).message == 'Unknown error code: 999'
     }
 
     @Test
     void testHandleCauseInExceptionConstructor() {
-        def cause = new RuntimeException("Test cause")
-        def exception = new InvalidArgumentWafException("Test message", -1, cause)
-
-        assert exception.message == "Test message"
+        RuntimeException cause = new RuntimeException('Test cause')
+        InvalidArgumentWafException exception = new InvalidArgumentWafException('Test message', -1, cause)
+        assert exception.message == 'Test message'
         assert exception.code == -1
         assert exception.cause == cause
     }
@@ -51,10 +50,10 @@ class AbstractWafExceptionTest {
          * with actual WAF error scenarios.
          */
         try {
-            AbstractWafException.createFromErrorCode(WafErrorCode.BINDING_ERROR.getCode())
-            fail("Expected IllegalStateException to be thrown")
+            AbstractWafException.createFromErrorCode(WafErrorCode.BINDING_ERROR.code)
+            fail('Expected IllegalStateException to be thrown')
         } catch (IllegalStateException e) {
-            assert e.message == "Unhandled WafErrorCode: BINDING_ERROR"
+            assert e.message == 'Unhandled WafErrorCode: BINDING_ERROR'
         }
     }
-} 
+}

--- a/src/test/groovy/com/datadog/ddwaf/exception/AbstractWafExceptionTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/exception/AbstractWafExceptionTest.groovy
@@ -27,16 +27,7 @@ class AbstractWafExceptionTest {
         assert AbstractWafException.createFromErrorCode(-1).message == 'Invalid argument'
         assert AbstractWafException.createFromErrorCode(-2).message == 'Invalid object'
         assert AbstractWafException.createFromErrorCode(-3).message == 'Internal error'
-        assert AbstractWafException.createFromErrorCode(999).message == 'Unknown error code: 999'
-    }
-
-    @Test
-    void testHandleCauseInExceptionConstructor() {
-        RuntimeException cause = new RuntimeException('Test cause')
-        InvalidArgumentWafException exception = new InvalidArgumentWafException('Test message', -1, cause)
-        assert exception.message == 'Test message'
-        assert exception.code == -1
-        assert exception.cause == cause
+        assert AbstractWafException.createFromErrorCode(999).message == 'Unclassified Waf exception with error code 999'
     }
 
     @Test

--- a/src/test/groovy/com/datadog/ddwaf/exception/AbstractWafExceptionTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/exception/AbstractWafExceptionTest.groovy
@@ -1,0 +1,60 @@
+package com.datadog.ddwaf.exception
+
+import com.datadog.ddwaf.WafErrorCode
+import org.junit.Test
+import static org.junit.Assert.fail
+
+class AbstractWafExceptionTest {
+
+    @Test
+    void testCreateCorrectExceptionTypesFromErrorCodes() {
+        assert AbstractWafException.createFromErrorCode(-1) instanceof InvalidArgumentWafException
+        assert AbstractWafException.createFromErrorCode(-2) instanceof InvalidObjectWafException
+        assert AbstractWafException.createFromErrorCode(-3) instanceof InternalWafException
+        assert AbstractWafException.createFromErrorCode(999) instanceof UnclassifiedWafException
+    }
+
+    @Test
+    void testSetCorrectErrorCodeInCreatedExceptions() {
+        assert AbstractWafException.createFromErrorCode(-1).code == -1
+        assert AbstractWafException.createFromErrorCode(-2).code == -2
+        assert AbstractWafException.createFromErrorCode(-3).code == -3
+        assert AbstractWafException.createFromErrorCode(999).code == 999
+    }
+
+    @Test
+    void testSetCorrectMessageInCreatedExceptions() {
+        assert AbstractWafException.createFromErrorCode(-1).message == "Invalid argument"
+        assert AbstractWafException.createFromErrorCode(-2).message == "Invalid object"
+        assert AbstractWafException.createFromErrorCode(-3).message == "Internal error"
+        assert AbstractWafException.createFromErrorCode(999).message == "Unknown error code: 999"
+    }
+
+    @Test
+    void testHandleCauseInExceptionConstructor() {
+        def cause = new RuntimeException("Test cause")
+        def exception = new InvalidArgumentWafException("Test message", -1, cause)
+
+        assert exception.message == "Test message"
+        assert exception.code == -1
+        assert exception.cause == cause
+    }
+
+    @Test
+    void testThrowIllegalStateExceptionForUnhandledWafErrorCode() {
+        /*
+         * We use BINDING_ERROR here as our test case because:
+         * 1. It's a special error code (-127) that by design is never returned by the WAF itself
+         * 2. It's only used to signal JNI binding-related issues
+         * 3. It's intentionally not handled in AbstractWafException.createFromErrorCode's switch statement
+         * This makes it perfect for testing the unhandled enum case without risking interference
+         * with actual WAF error scenarios.
+         */
+        try {
+            AbstractWafException.createFromErrorCode(WafErrorCode.BINDING_ERROR.getCode())
+            fail("Expected IllegalStateException to be thrown")
+        } catch (IllegalStateException e) {
+            assert e.message == "Unhandled WafErrorCode: BINDING_ERROR"
+        }
+    }
+} 

--- a/src/test/groovy/com/datadog/ddwaf/exception/UnclassifiedWafExceptionTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/exception/UnclassifiedWafExceptionTest.groovy
@@ -1,0 +1,43 @@
+package com.datadog.ddwaf.exception
+
+import com.datadog.ddwaf.WafErrorCode
+import org.junit.Test
+
+class UnclassifiedWafExceptionTest {
+
+    @Test
+    void testConstructorWithErrorCode() {
+        def exception = new UnclassifiedWafException(999)
+        assert exception.message == "Unclassified Waf exception with error code 999"
+        assert exception.code == 999
+    }
+
+    @Test
+    void testConstructorWithMessage() {
+        def message = "Test error message"
+        def exception = new UnclassifiedWafException(message)
+        assert exception.message == message
+        assert exception.code == WafErrorCode.BINDING_ERROR.getCode()
+    }
+
+    @Test
+    void testConstructorWithMessageAndCause() {
+        def message = "Test error message"
+        def cause = new RuntimeException("Test cause")
+        def exception = new UnclassifiedWafException(message, cause)
+        
+        assert exception.message == message
+        assert exception.code == WafErrorCode.BINDING_ERROR.getCode()
+        assert exception.cause == cause
+    }
+
+    @Test
+    void testConstructorWithThrowable() {
+        def cause = new RuntimeException("Test cause")
+        def exception = new UnclassifiedWafException(cause)
+        
+        assert exception.message == "Test cause"
+        assert exception.code == WafErrorCode.BINDING_ERROR.getCode()
+        assert exception.cause == cause
+    }
+} 

--- a/src/test/groovy/com/datadog/ddwaf/exception/UnclassifiedWafExceptionTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/exception/UnclassifiedWafExceptionTest.groovy
@@ -7,37 +7,35 @@ class UnclassifiedWafExceptionTest {
 
     @Test
     void testConstructorWithErrorCode() {
-        def exception = new UnclassifiedWafException(999)
-        assert exception.message == "Unclassified Waf exception with error code 999"
+        UnclassifiedWafException exception = new UnclassifiedWafException(999)
+        assert exception.message == 'Unclassified Waf exception with error code 999'
         assert exception.code == 999
     }
 
     @Test
     void testConstructorWithMessage() {
-        def message = "Test error message"
-        def exception = new UnclassifiedWafException(message)
+        String message = 'Test error message'
+        UnclassifiedWafException exception = new UnclassifiedWafException(message)
         assert exception.message == message
-        assert exception.code == WafErrorCode.BINDING_ERROR.getCode()
+        assert exception.code == WafErrorCode.BINDING_ERROR.code
     }
 
     @Test
     void testConstructorWithMessageAndCause() {
-        def message = "Test error message"
-        def cause = new RuntimeException("Test cause")
-        def exception = new UnclassifiedWafException(message, cause)
-        
+        String message = 'Test error message'
+        RuntimeException cause = new RuntimeException('Test cause')
+        UnclassifiedWafException exception = new UnclassifiedWafException(message, cause)
         assert exception.message == message
-        assert exception.code == WafErrorCode.BINDING_ERROR.getCode()
+        assert exception.code == WafErrorCode.BINDING_ERROR.code
         assert exception.cause == cause
     }
 
     @Test
     void testConstructorWithThrowable() {
-        def cause = new RuntimeException("Test cause")
-        def exception = new UnclassifiedWafException(cause)
-        
-        assert exception.message == "Test cause"
-        assert exception.code == WafErrorCode.BINDING_ERROR.getCode()
+        RuntimeException cause = new RuntimeException('Test cause')
+        UnclassifiedWafException exception = new UnclassifiedWafException(cause)
+        assert exception.message == 'Test cause'
+        assert exception.code == WafErrorCode.BINDING_ERROR.code
         assert exception.cause == cause
     }
-} 
+}


### PR DESCRIPTION
- Improves propagation of error codes from native WAF responses

- Ensures bindings return -127 in case of errors before calling into the WAF

- Adds constants for WAF return codes

- Add tests cases