### PR TITLE
Upgrade libddwaf to 1.25.1

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ defaults:
 env:
   buildType: RelWithDebInfo
   tempdir: ${{ github.workspace }}/build
-  libddwafVersion: 1.24.1
+  libddwafVersion: 1.25.1
 jobs:
   Spotless:
     name: spotless

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ repositories {
 }
 
 group 'io.sqreen'
-version '14.1.0'
+version '15.0.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/c/waf_jni.c
+++ b/src/main/c/waf_jni.c
@@ -2038,7 +2038,8 @@ static void _update_metrics(JNIEnv *env, jobject metrics_obj,
     // metrics update
     if (!JNI(IsSameObject, metrics_obj, NULL)) {
         // Get duration from the ddwaf_object structure
-        const ddwaf_object *duration_obj = ddwaf_object_find(ret, "duration", 8);
+        const ddwaf_object *duration_obj =
+                ddwaf_object_find(ret, "duration", 8);
         jlong duration = 0;
         if (duration_obj != NULL && duration_obj->type == DDWAF_OBJ_UNSIGNED) {
             duration = (jlong) ddwaf_object_get_unsigned(duration_obj);
@@ -2176,7 +2177,8 @@ static jobject _create_result_checked(JNIEnv *env, DDWAF_RET_CODE code,
     }
 
     // Get attributes (formerly derivatives) from the new ddwaf_object structure
-    const ddwaf_object *attributes_obj = ddwaf_object_find(ret, "attributes", 10);
+    const ddwaf_object *attributes_obj =
+            ddwaf_object_find(ret, "attributes", 10);
     jobject derivatives = NULL;
     if (attributes_obj != NULL && attributes_obj->type == DDWAF_OBJ_MAP &&
         ddwaf_object_size(attributes_obj) > 0) {
@@ -2206,7 +2208,8 @@ err:
 
 static inline bool _has_derivative(const ddwaf_object *res)
 {
-    const ddwaf_object *attributes_obj = ddwaf_object_find(res, "attributes", 10);
+    const ddwaf_object *attributes_obj =
+            ddwaf_object_find(res, "attributes", 10);
     return attributes_obj != NULL && attributes_obj->type == DDWAF_OBJ_MAP &&
            ddwaf_object_size(attributes_obj) > 0;
 }

--- a/src/main/java/com/datadog/ddwaf/Waf.java
+++ b/src/main/java/com/datadog/ddwaf/Waf.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class Waf {
-  public static final String LIB_VERSION = "1.24.1";
+  public static final String LIB_VERSION = "1.25.1";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Waf.class);
   static final boolean EXIT_ON_LEAK;

--- a/src/test/groovy/com/datadog/ddwaf/ObfuscationTests.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/ObfuscationTests.groovy
@@ -49,7 +49,7 @@ class ObfuscationTests implements WafTrait {
     def json = slurper.parseText(awd.data)
 
     assert json[0].rule_matches[0]['parameters'][0].key_path == ['user-agent', '0']
-    assert json[0].rule_matches[0]['parameters'][0].value == '<Redacted>'
+    assert json[0].rule_matches[0]['parameters'][0].value == 'Arachni/v1 password=<Redacted>'
     assert json[0].rule_matches[0]['parameters'][0].highlight == ['<Redacted>']
   }
 


### PR DESCRIPTION
Upgrades libddwaf to 1.25.1, this version removes the ddwaf_result object and advises the use of ddwaf_object
https://github.com/DataDog/libddwaf/blob/master/UPGRADING.md#upgrading-from-124x-to-1250