### PR TITLE
ci: migrate macOS CI runners from deprecated macos-13 to macos-14

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -91,7 +91,7 @@ jobs:
           extra-args: build/reports/jacoco/test/jacocoTestReport.xml
   Native_binaries_Stage_macos_x86_64:
     name: MacOS x86_64
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       generator: Unix Makefiles
       shlib_prefix: lib
@@ -102,9 +102,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       name: Checkout
-    - name: Select Xcode version
-      # Matches libddwaf https://github.com/DataDog/libddwaf/blob/6aabaa97fb224c251dacc70e427a4c1d7d985af4/.github/workflows/build.yml#L68-L69
-      run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
     - name: Prepare libddwaf
       run: |
         # Get sha256sum
@@ -148,7 +145,7 @@ jobs:
 
   Native_binaries_Stage_macos_aarch64:
     name: MacOS aarch64
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       generator: Unix Makefiles
       shlib_prefix: lib
@@ -159,9 +156,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         name: Checkout
-      - name: Select Xcode version
-        # Matches libddwaf https://github.com/DataDog/libddwaf/blob/6aabaa97fb224c251dacc70e427a4c1d7d985af4/.github/workflows/build.yml#L68-L69
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
       - name: Prepare libddwaf
         run: |
           # Get sha256sum
@@ -551,7 +545,7 @@ jobs:
             arch: aarch64
             docker_image: alpine-stock8
             test_java_home_var: JAVA_8_HOME
-          - runs-on: macos-13
+          - runs-on: macos-14-large
             os: macos
             arch: x86_64
             jdk: temurin8
@@ -561,7 +555,7 @@ jobs:
             arch: x86_64
             jdk: temurin8
             java_home_var: JAVA_HOME_8_X64
-          - runs-on: macos-13-xlarge
+          - runs-on: macos-14
             os: macos
             arch: aarch64
             jdk: temurin11
@@ -581,7 +575,7 @@ jobs:
             arch: aarch64
             jdk: temurin11
             java_home_var: JAVA_HOME_11_arm64
-          - runs-on: macos-13
+          - runs-on: macos-14-large
             os: macos
             arch: x86_64
             jdk: temurin17

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -91,7 +91,7 @@ jobs:
           extra-args: build/reports/jacoco/test/jacocoTestReport.xml
   Native_binaries_Stage_macos_x86_64:
     name: MacOS x86_64
-    runs-on: macos-14
+    runs-on: macos-14-large
     env:
       generator: Unix Makefiles
       shlib_prefix: lib

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -550,11 +550,6 @@ jobs:
             arch: x86_64
             jdk: temurin8
             java_home_var: JAVA_HOME_8_X64
-          - runs-on: macos-14-large
-            os: macos
-            arch: x86_64
-            jdk: temurin8
-            java_home_var: JAVA_HOME_8_X64
           - runs-on: macos-14
             os: macos
             arch: aarch64
@@ -565,11 +560,6 @@ jobs:
             arch: x86_64
             jdk: temurin11
             java_home_var: JAVA_HOME_11_X64
-          - runs-on: macos-14
-            os: macos
-            arch: aarch64
-            jdk: temurin11
-            java_home_var: JAVA_HOME_11_arm64
           - runs-on: macos-15
             os: macos
             arch: aarch64


### PR DESCRIPTION
## Summary

- Replaces deprecated `macos-13` runner images across the CI matrix with current equivalents:
  - `macos-13` (Intel x86\_64) → `macos-14-large` for x86\_64 jobs (`Native_binaries_Stage_macos_x86_64` and test matrix)
  - `macos-13` / `macos-13-xlarge` (aarch64) → `macos-14` for arm64 jobs (`Native_binaries_Stage_macos_aarch64` and test matrix)
- Removes explicit `xcode-select --switch /Applications/Xcode_14.3.1.app` step — `macos-14` ships with a compatible Xcode version
- Removes duplicate test matrix rows for `temurin8/x86\_64` and `temurin11/aarch64` that appeared after the migration (the old `macos-13` and `macos-13-xlarge` entries were identical to rows already present in the matrix targeting `macos-14-large` and `macos-14`)

> **Note:** `macos-14` is Apple Silicon (arm64) and `macos-14-large` is Intel x86\_64 — the naming is counter-intuitive but documented in [actions/runner-images](https://github.com/actions/runner-images#available-images).

## Test plan

- [ ] CI passes on `macos-14-large` (x86\_64 native binary build + tests)
- [ ] CI passes on `macos-14` (arm64 native binary build + tests)

Jira ticket: N/A