### PR TITLE
ci: fix CentOS 6 SSL failures with Temurin 8 cacerts

### DIFF
--- a/ci/centos6-stock8/Dockerfile
+++ b/ci/centos6-stock8/Dockerfile
@@ -13,5 +13,5 @@ RUN keytool -importkeystore \
       -destkeystore "$JAVA_HOME/jre/lib/security/cacerts" \
       -srcstorepass  changeit \
       -deststorepass changeit \
-      -noprompt 2>/dev/null; \
+      -noprompt 2>/dev/null && \
     rm /tmp/temurin-cacerts

--- a/ci/centos6-stock8/Dockerfile
+++ b/ci/centos6-stock8/Dockerfile
@@ -4,3 +4,14 @@ RUN set -eux; \
     yum install -y java-1.8.0-openjdk-devel
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk.x86_64
 ENV JAVA_8_HOME=/usr/lib/jvm/java-1.8.0-openjdk.x86_64
+# CentOS 6 reached EOL in 2020; its JDK cacerts no longer include the CA chains
+# used by modern HTTPS endpoints (Gradle distribution servers, Maven Central).
+# Replace the stale cacerts with those from Eclipse Temurin 8, which are current.
+COPY --from=eclipse-temurin:8-jdk /opt/java/openjdk/jre/lib/security/cacerts /tmp/temurin-cacerts
+RUN keytool -importkeystore \
+      -srckeystore  /tmp/temurin-cacerts \
+      -destkeystore "$JAVA_HOME/jre/lib/security/cacerts" \
+      -srcstorepass  changeit \
+      -deststorepass changeit \
+      -noprompt 2>/dev/null; \
+    rm /tmp/temurin-cacerts


### PR DESCRIPTION
## Summary

- Imports Temurin 8 cacerts into the CentOS 6 Docker image to fix SSL failures when downloading dependencies
- Fixes the cacerts path for JDK 8 (`jre/lib/security/` instead of `lib/security/`)

## Test plan

- [ ] CI passes on the `centos6-stock8` job