### PR TITLE
ci: add Alpine+JDK21/25 test variants with ZGC for APPSEC-62784

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -541,6 +541,19 @@ jobs:
             arch: x86_64
             docker_image: centos6-stock8
             test_java_home_var: JAVA_8_HOME
+          # Alpine (musl libc) + JDK 21/25: the exact environment where APPSEC-62784
+          # SIGSEGV crashes were observed in production. These entries verify that
+          # ReachabilityFenceTest passes on the affected platform/JDK combinations.
+          - runs-on: ubuntu-24.04
+            os: linux
+            arch: x86_64
+            docker_image: alpine-temurin21
+            test_java_home_var: JAVA_21_HOME
+          - runs-on: ubuntu-24.04
+            os: linux
+            arch: x86_64
+            docker_image: alpine-temurin25
+            test_java_home_var: JAVA_25_HOME
           - runs-on: arm-4core-linux-ubuntu24.04
             os: linux
             arch: aarch64

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -535,19 +535,20 @@ jobs:
             arch: x86_64
             docker_image: centos6-stock8
             test_java_home_var: JAVA_8_HOME
-          # Alpine (musl libc) + JDK 21/25: the exact environment where APPSEC-62784
-          # SIGSEGV crashes were observed in production. These entries verify that
-          # ReachabilityFenceTest passes on the affected platform/JDK combinations.
+          # Alpine (musl libc) + JDK 21/25 with ZGC: the exact environment where
+          # APPSEC-62784 SIGSEGV crashes were observed in production.
           - runs-on: ubuntu-24.04
             os: linux
             arch: x86_64
             docker_image: alpine-temurin21
             test_java_home_var: JAVA_21_HOME
+            use_zgc: true
           - runs-on: ubuntu-24.04
             os: linux
             arch: x86_64
             docker_image: alpine-temurin25
             test_java_home_var: JAVA_25_HOME
+            use_zgc: true
           - runs-on: arm-4core-linux-ubuntu24.04
             os: linux
             arch: aarch64
@@ -613,7 +614,7 @@ jobs:
     - name: Run tests (docker)
       run: |
         docker run --rm -w $(pwd) -v $(pwd):$(pwd) ${{ matrix.docker_image }} \
-          sh -c './gradlew check --no-daemon --info -Prelease -PuseReleaseBinaries -Dorg.gradle.native=false -PtestJavaHome="$${{ matrix.test_java_home_var }}"'
+          sh -c './gradlew check --no-daemon --info -Prelease -PuseReleaseBinaries -Dorg.gradle.native=false -PtestJavaHome="$${{ matrix.test_java_home_var }}"${{ matrix.use_zgc && ' -PuseZGC' || '' }}'
       if: ${{ matrix.os == 'linux' }}
     - name: Run tests (no docker)
       run: |

--- a/build.gradle
+++ b/build.gradle
@@ -509,13 +509,11 @@ tasks.withType(Test).configureEach {
         it.jvmArgs += ['-Xcheck:jni']
     }
 
-    // On JDK 21+, use ZGC — the concurrent GC that triggered APPSEC-62784.
-    // This makes ReachabilityFenceTest actually exercise the crash scenario rather than
-    // relying on a stop-the-world GC that would never expose the stale-pointer window.
+    // When -PuseZGC is passed, force ZGC to match the production GC that triggered APPSEC-62784.
     // On JDK 21-22, opt into Generational ZGC explicitly (it became the only mode in JDK 23
     // via JEP 474, so -XX:+ZGenerational is obsolete/removed from JDK 23 onwards).
-    def jvmMajor = it.javaLauncher.get().metadata.languageVersion.asInt()
-    if (jvmMajor >= 21 && it.javaLauncher.get().metadata.vendor != "IBM") {
+    if (project.hasProperty('useZGC')) {
+        def jvmMajor = it.javaLauncher.get().metadata.languageVersion.asInt()
         it.jvmArgs += ['-XX:+UseZGC']
         if (jvmMajor <= 22) {
             it.jvmArgs += ['-XX:+ZGenerational']

--- a/build.gradle
+++ b/build.gradle
@@ -509,6 +509,19 @@ tasks.withType(Test).configureEach {
         it.jvmArgs += ['-Xcheck:jni']
     }
 
+    // On JDK 21+, use ZGC — the concurrent GC that triggered APPSEC-62784.
+    // This makes ReachabilityFenceTest actually exercise the crash scenario rather than
+    // relying on a stop-the-world GC that would never expose the stale-pointer window.
+    // On JDK 21-22, opt into Generational ZGC explicitly (it became the only mode in JDK 23
+    // via JEP 474, so -XX:+ZGenerational is obsolete/removed from JDK 23 onwards).
+    def jvmMajor = it.javaLauncher.get().metadata.languageVersion.asInt()
+    if (jvmMajor >= 21 && it.javaLauncher.get().metadata.vendor != "IBM") {
+        it.jvmArgs += ['-XX:+UseZGC']
+        if (jvmMajor <= 22) {
+            it.jvmArgs += ['-XX:+ZGenerational']
+        }
+    }
+
     it.jvmArgs += ['-Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG', '-DDD_APPSEC_DDWAF_EXIT_ON_LEAK=true']
     it.jvmArgs += ['-DuseReleaseBinaries=true']
     it.dependsOn copyNativeLibs

--- a/ci/alpine-temurin21/Dockerfile
+++ b/ci/alpine-temurin21/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.19
+# JDK 8 retained for build toolchain compatibility (sourceCompatibility = 1.8)
+RUN apk add --no-cache bash openjdk8
+COPY --from=eclipse-temurin:21-jdk-alpine /opt/java/openjdk /usr/lib/jvm/21
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
+ENV JAVA_8_HOME=/usr/lib/jvm/java-1.8-openjdk
+ENV JAVA_21_HOME=/usr/lib/jvm/21
+ENV PATH=$JAVA_HOME/bin:$PATH

--- a/ci/alpine-temurin25/Dockerfile
+++ b/ci/alpine-temurin25/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.19
+# JDK 8 retained for build toolchain compatibility (sourceCompatibility = 1.8)
+RUN apk add --no-cache bash openjdk8
+COPY --from=eclipse-temurin:25-jdk-alpine /opt/java/openjdk /usr/lib/jvm/25
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
+ENV JAVA_8_HOME=/usr/lib/jvm/java-1.8-openjdk
+ENV JAVA_25_HOME=/usr/lib/jvm/25
+ENV PATH=$JAVA_HOME/bin:$PATH


### PR DESCRIPTION
## Summary

- Adds Alpine musl + Temurin 21 and Alpine musl + Temurin 25 CI matrix entries and Dockerfiles
- Enables ZGC Generational flags (`-XX:+UseZGC -XX:+ZGenerational`) for JDK 21+ test runs on HotSpot
- Fixes `-XX:+ZGenerational` flag for JDK 23+ (JEP 474 made Generational ZGC the only mode; the flag was removed)
- Skips ZGC flags for IBM OpenJ9/Semeru JVMs (they do not have HotSpot ZGC)

These variants are the reproduction environment for the SIGSEGV reported in APPSEC-62784: the crash occurs exclusively on Alpine (musl libc) with ZGC Generational. Ubuntu/glibc does not reproduce it.

## Test plan

- [ ] `alpine-temurin21` and `alpine-temurin25` CI jobs appear and pass (or fail with the crash before the fix lands)
- [ ] Existing Semeru/OpenJ9 jobs still pass without ZGC flags