### PR TITLE
ci: pin all GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -219,7 +219,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         name: Checkout
-      - uses: ilammy/msvc-dev-cmd@7defe9254715b088f12dddd9942945a3d75cdad5 # v1.9.0
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         name: Setup x86_64 build
         with:
           vsversion: 2022

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: "!(contains(github.ref, 'refs/tags/v'))"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         name: Checkout
         with:
           submodules: recursive
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: "!(contains(github.ref, 'refs/tags/v'))"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         name: Checkout
         with:
           submodules: recursive
@@ -46,13 +46,13 @@ jobs:
       contents: read
       id-token: write # needed for dd-sts OIDC token exchange
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         name: Checkout
         with:
           submodules: recursive
           clean: true
       - name: Cache Gradle artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.gradle/caches
@@ -68,7 +68,7 @@ jobs:
           sudo apt-get install -y gcovr
           gcovr -f '.*src/main/c/.*' -x -d -o build/coverage.xml
       - name: Submit coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2.1.0
         with:
           flags: helper
           verbose: true
@@ -100,7 +100,7 @@ jobs:
       artifactsuff: macos-x86_64
       libdir: macos/x86_64
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       name: Checkout
     - name: Select Xcode version
       # Matches libddwaf https://github.com/DataDog/libddwaf/blob/6aabaa97fb224c251dacc70e427a4c1d7d985af4/.github/workflows/build.yml#L68-L69
@@ -141,7 +141,7 @@ jobs:
           ${{ github.workspace }}/native_libs/${{ env.libdir }}
       working-directory: ${{ env.tempdir }}/buildAG
     - name: Save Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         path: native_libs
         name: libsqreen_jni_${{ env.artifactsuff }}
@@ -157,7 +157,7 @@ jobs:
       artifactsuff: macos-aarch64
       libdir: macos/aarch64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         name: Checkout
       - name: Select Xcode version
         # Matches libddwaf https://github.com/DataDog/libddwaf/blob/6aabaa97fb224c251dacc70e427a4c1d7d985af4/.github/workflows/build.yml#L68-L69
@@ -198,7 +198,7 @@ jobs:
             ${{ github.workspace }}/native_libs/${{ env.libdir }}
         working-directory: ${{ env.tempdir }}/buildAG
       - name: Save Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           path: native_libs
           name: libsqreen_jni_${{ env.artifactsuff }}
@@ -217,9 +217,9 @@ jobs:
       artifactsuff: win-x86_64
       libdir: windows/x86_64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         name: Checkout
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@7defe9254715b088f12dddd9942945a3d75cdad5 # v1.9.0
         name: Setup x86_64 build
         with:
           vsversion: 2022
@@ -248,7 +248,7 @@ jobs:
         shell: cmd
         working-directory: ${{ env.tempdir }}/buildAG
       - name: Save Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           path: native_libs
           name: libsqreen_jni_${{ env.artifactsuff }}
@@ -281,7 +281,7 @@ jobs:
       libdir: linux/${{ matrix.arch }}/${{ matrix.libc }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Prepare libddwaf
         run: |
           wget https://github.com/DataDog/libddwaf/releases/download/${{ env.libddwafVersion }}/libddwaf-${{ env.libddwafVersion }}-${{ matrix.arch }}-linux-musl.tar.gz
@@ -305,7 +305,7 @@ jobs:
             cp -v *.so *.so.debug ${{ github.workspace }}/native_libs/${{ env.libdir }}'
         shell: bash
       - name: Save Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           path: native_libs
           name: jni_${{ env.artifactsuff }}
@@ -315,7 +315,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout project
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         submodules: recursive
     - name: Install GCC and clang
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout project
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         submodules: recursive
     - name: Install GCC and clang
@@ -359,12 +359,12 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         submodules: recursive
         clean: true
     - name: Setup JDK 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         java-version: 11
         distribution: temurin
@@ -379,12 +379,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         submodules: recursive
         clean: true
     - name: Setup JDK 8
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         java-version: 8
         distribution: temurin
@@ -403,54 +403,54 @@ jobs:
       - Native_binaries_Stage_static_analyzer
     steps:
     - name: Setup JDK 1.8
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         java-version: 8
         distribution: temurin
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       name: Checkout
       with:
         submodules: recursive
         clean: true
     - name: Download libsqreen_jni_win-x86_64
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: libsqreen_jni_win-x86_64
         path: native_libs
     - name: Download jni_linux_glibc-x86_64
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: jni_linux_glibc-x86_64
         path: native_libs
     - name: Download jni_linux_glibc-aarch64
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: jni_linux_glibc-aarch64
         path: native_libs
     - name: Download jni_linux_musl-x86_64
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: jni_linux_musl-x86_64
         path: native_libs
     - name: Download jni_linux_musl-aarch64
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: jni_linux_musl-aarch64
         path: native_libs
     - name: Download libsqreen_jni_macos-x86_64
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: libsqreen_jni_macos-x86_64
         path: native_libs
     - name: Download libsqreen_jni_macos_aarch64
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: libsqreen_jni_macos-aarch64
         path: native_libs
     - run: find .
       working-directory: native_libs
     - name: Cache Gradle artifacts
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.gradle/caches
@@ -468,12 +468,12 @@ jobs:
         cp ${{ github.workspace }}/build/distributions/libsqreen-*-dbgsym.zip "${{ env.tempdir }}/packages"
       shell: bash
     - name: Publish artifacts (native libs)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         path: native_libs
         name: native_libs
     - name: Publish artifacts (jars)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         path: ${{ env.tempdir }}/packages
         name: libsqreen_jni_jar
@@ -603,10 +603,10 @@ jobs:
             java_home_var: JAVA_HOME_8_X64
     runs-on: ${{ matrix.runs-on }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       name: Checkout
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: native_libs
         path: native_libs
@@ -649,17 +649,17 @@ jobs:
     if: contains(github.ref, 'refs/tags/v')
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         submodules: recursive
         clean: true
     - name: Setup JDK 1.8
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         java-version: 8
         distribution: temurin
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: native_libs
         path: native_libs


### PR DESCRIPTION
## Summary

- Pins all GitHub Actions references to full-length commit SHAs per enterprise policy
  - `actions/checkout@v4` → `34e1148` (v4.3.1)
  - `actions/upload-artifact@v4` → `ea165f8` (v4.6.2)
  - `actions/cache@v4` → `0057852` (v4.3.0)
  - `actions/setup-java@v4` → `c1e3236` (v4.8.0)
  - `actions/download-artifact@v4` → `d3f86a1` (v4.3.0)
  - `ilammy/msvc-dev-cmd@v1` → `7defe92` (v1.9.0)
  - `codecov/codecov-action@v2` → `f32b3a3` (v2.1.0)

## Test plan

- [ ] CI passes (no functional change, SHA-pinned refs resolve to the same action code)

Jira ticket: N/A