### PR TITLE
Add regression test for runEphemeral() PWArgsSegment freed by ZGC (APPSEC-68682)

### DIFF
--- a/src/test/groovy/com/datadog/ddwaf/ReachabilityFenceTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/ReachabilityFenceTest.groovy
@@ -246,49 +246,62 @@ class ReachabilityFenceTest implements WafTrait {
    * raw pointers into them.
    *
    * Distinct from APPSEC-62784 (StringsSegment freed via run()) but same root cause and fix.
+   *
+   * Requires testGCRace task: relies on -XX:-TieredCompilation -XX:CompileThreshold=1 so
+   * WafContext.run() reaches C2 immediately without a warmup phase.
    */
   @Test
-  @SuppressWarnings(['ExplicitGarbageCollection', 'BusyWait'])
+  @SuppressWarnings('ExplicitGarbageCollection')
   void 'ephemeral arena with nested map survives concurrent GC (APPSEC-68682)'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V2_1)
+    wafDiagnostics = builder.addOrUpdateConfig('test', serverResponseBodyRuleset())
+    assert wafDiagnostics.numConfigOK == 1, "Rule must load: ${wafDiagnostics.allErrors}"
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
     runBudget = 60_000_000L
 
     // Simulate ObjectIntrospection.convert() output for a streaming SSE response POJO.
     // Nested structure forces multiple PWArgsSegment allocations in the ephemeral arena.
-    Map<String, Object> ephemeralData = (Map<String, Object>) [
-      'server.response.body': (Map<String, Object>) [
-        field1: (Map<String, Object>) [
+    // match_regex on server.response.body triggers eval_rules() which traverses all nested
+    // MAP entries, reading the PWArgsSegments that are freed without the leaseFenceSink fix.
+    def ephemeralData = [
+      'server.response.body': [
+        field1: [
           subA: 'value1',
           subB: null,
-          subC: (Map<String, Object>) [deepA: 'deep1', deepB: null, deepC: 'deep3'],
+          subC: [deepA: 'deep1', deepB: null, deepC: 'deep3'],
         ],
         field2: null,
-        field3: (Map<String, Object>) [
+        field3: [
           subD: 'value2',
-          subE: (Map<String, Object>) [x: '1', y: '2', z: '3'],
+          subE: [x: '1', y: '2', z: '3'],
         ],
         field4: 'scalar',
-        field5: (Map<String, Object>) [nestedA: 'a', nestedB: 'b'],
+        field5: [nestedA: 'a', nestedB: 'b'],
       ],
     ]
 
     def keepRunningGc = new AtomicBoolean(true)
-    def gcThread = Thread.startDaemon('gc-pressure-ephemeral') {
-      while (keepRunningGc.get()) {
-        System.gc()
-        Thread.sleep(1)
+    def gcThreads4 = (0..<3).collect { int n ->
+      Thread.startDaemon("gc-pressure-ephemeral-${n}") {
+        while (keepRunningGc.get()) {
+          System.gc()
+          Thread.sleep(1)
+        }
       }
     }
 
     try {
-      500.times {
-        context.runEphemeral(ephemeralData, limits, metrics)
+      500.times { int i ->
+        def result = context.runEphemeral(ephemeralData, limits, metrics)
+        assertThat(
+          "Iteration ${i}: expected DDWAF_OK (regex never matches response body)",
+          result.result,
+          is(Waf.Result.OK))
       }
     } finally {
       keepRunningGc.set(false)
-      gcThread.join(1000)
+      gcThreads4.each { it.join(1000) }
+      ByteBufferSerializer.ArenaPool.INSTANCE.arenas.clear()
     }
   }
 
@@ -345,6 +358,36 @@ class ReachabilityFenceTest implements WafTrait {
                 ],
                 regex  : '[a-zA-Z0-9]+[.][a-zA-Z0-9]{2,5}[.][a-zA-Z0-9]{2,5}$',
                 options: [case_sensitive: true, min_length: 6],
+              ],
+            ]
+          ],
+          transformers: [],
+        ],
+      ],
+    ]
+  }
+
+  /**
+   * Minimal ruleset targeting server.response.body with a match_regex that never matches.
+   * The rule evaluator traverses all nested MAP entries at server.response.body, reading
+   * the ephemeral PWArgsSegments that are freed without the leaseFenceSink fix (APPSEC-68682).
+   */
+  static Map serverResponseBodyRuleset() {
+    [
+      version : '2.1',
+      metadata: [rules_version: '1.0.0'],
+      rules   : [
+        [
+          id        : 'test-appsec-68682-body-inspection',
+          name      : 'Response body inspection (APPSEC-68682 regression)',
+          tags      : [type: 'test', category: 'test', module: 'waf'],
+          conditions: [
+            [
+              operator  : 'match_regex',
+              parameters: [
+                inputs : [[address: 'server.response.body']],
+                regex  : 'IMPOSSIBLE_APPSEC68682_MARKER',
+                options: [case_sensitive: true, min_length: 30],
               ],
             ]
           ],

--- a/src/test/groovy/com/datadog/ddwaf/ReachabilityFenceTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/ReachabilityFenceTest.groovy
@@ -18,20 +18,23 @@ import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.is
 
 /**
- * Regression tests for APPSEC-62784: SIGSEGV crash in libddwaf on JDK 21.0.8+/JDK 25.
+ * Regression tests for APPSEC-62784 and APPSEC-68682: SIGSEGV crash in libddwaf on
+ * JDK 21.0.8+/JDK 25.
  *
- * Root cause: StringsSegment DirectByteBuffers could be prematurely freed by the
- * concurrent GC Cleaner thread while ddwaf_run() was still reading native pointers
- * into them. The JIT in ZGC Generational / JDK 25 is more aggressive at eliding
+ * Root cause: StringsSegment and PWArgsSegment DirectByteBuffers could be prematurely
+ * freed by the concurrent GC Cleaner thread while ddwaf_run() was still reading native
+ * pointers into them. The JIT in ZGC Generational / JDK 25 is more aggressive at eliding
  * references it considers "dead" after the last Java-visible use.
  *
- * Fix: a volatile-write fence (leaseFenceSink = lease) immediately after runWafContext()
- * returns, ensuring the Arena's StringsSegment DirectByteBuffers remain strongly
- * reachable until past the ddwaf_run boundary.
+ * Fix: a volatile-write fence (leaseFenceSink = lease) in the finally block of
+ * WafContext.run(), ensuring all Arena DirectByteBuffers remain strongly reachable
+ * until past the ddwaf_run boundary.
  *
- * Rules that reproduce the crash pattern: match_regex on server.request.headers.no_cookies
- * with key_path values (x-filename, x_filename, etc.) that are absent from most requests —
- * exactly the pattern introduced in dd-trace-java 1.62.0 bundled ruleset (PR #11093).
+ * APPSEC-62784 crash pattern: DDWAF_OBJ_STRING with dangling stringValue pointer
+ * (StringsSegment freed), triggered by key_path header rules on absent headers.
+ *
+ * APPSEC-68682 crash pattern: DDWAF_OBJ_MAP with entries=null (PWArgsSegment freed),
+ * triggered by runEphemeral() with deeply nested Maps from SSE response body inspection.
  */
 class ReachabilityFenceTest implements WafTrait {
 
@@ -230,6 +233,63 @@ class ReachabilityFenceTest implements WafTrait {
     }
 
     assert errors.empty, "Errors during concurrent run:\n${errors.join('\n')}"
+  }
+
+  /**
+   * Regression test for APPSEC-68682: ephemeral arena freed during ddwaf_run under ZGC.
+   *
+   * Trigger: SSE streaming response body inspection in Spring MVC. Each SSE chunk calls
+   * runEphemeral() with a deeply nested Map from ObjectIntrospection.convert() on a POJO.
+   * The nested structure creates multiple PWArgsSegment allocations in the ephemeral arena.
+   * Without the leaseFenceSink fence, the JIT eliminates ephemeralLease from the GC OopMap
+   * before the JNI safepoint, and ZGC frees the DirectByteBuffers while ddwaf_run holds
+   * raw pointers into them.
+   *
+   * Distinct from APPSEC-62784 (StringsSegment freed via run()) but same root cause and fix.
+   */
+  @Test
+  @SuppressWarnings(['ExplicitGarbageCollection', 'BusyWait'])
+  void 'ephemeral arena with nested map survives concurrent GC (APPSEC-68682)'() {
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V2_1)
+    handle = builder.buildWafHandleInstance()
+    context = new WafContext(handle)
+    runBudget = 60_000_000L
+
+    // Simulate ObjectIntrospection.convert() output for a streaming SSE response POJO.
+    // Nested structure forces multiple PWArgsSegment allocations in the ephemeral arena.
+    Map<String, Object> ephemeralData = (Map<String, Object>) [
+      'server.response.body': (Map<String, Object>) [
+        field1: (Map<String, Object>) [
+          subA: 'value1',
+          subB: null,
+          subC: (Map<String, Object>) [deepA: 'deep1', deepB: null, deepC: 'deep3'],
+        ],
+        field2: null,
+        field3: (Map<String, Object>) [
+          subD: 'value2',
+          subE: (Map<String, Object>) [x: '1', y: '2', z: '3'],
+        ],
+        field4: 'scalar',
+        field5: (Map<String, Object>) [nestedA: 'a', nestedB: 'b'],
+      ],
+    ]
+
+    def keepRunningGc = new AtomicBoolean(true)
+    def gcThread = Thread.startDaemon('gc-pressure-ephemeral') {
+      while (keepRunningGc.get()) {
+        System.gc()
+        Thread.sleep(1)
+      }
+    }
+
+    try {
+      500.times {
+        context.runEphemeral(ephemeralData, limits, metrics)
+      }
+    } finally {
+      keepRunningGc.set(false)
+      gcThread.join(1000)
+    }
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?

Extends `ReachabilityFenceTest` to cover the APPSEC-68682 crash pattern:

- Adds `'ephemeral arena with nested map survives concurrent GC (APPSEC-68682)'` test method that calls `runEphemeral()` 500 times with a deeply nested `Map` (simulating `ObjectIntrospection.convert()` output on a Spring MVC SSE response POJO)
- Adds `serverResponseBodyRuleset()` helper: a `match_regex` rule on `server.response.body` that ensures `check_new_rule_targets()` returns true and `eval_rules()` traverses all nested `PWArgsSegment` allocations in the ephemeral arena
- Updates class-level Javadoc to document both APPSEC-62784 and APPSEC-68682 crash patterns

Without the `leaseFenceSink` fix from PR #198, the new test crashes with SIGSEGV on JDK 21.0.8+ with ZGC Generational.

### Motivation

APPSEC-68682: SIGSEGV in `ddwaf_run` triggered by SSE streaming + Spring MVC `@ResponseBody` POJO inspection (`ObjectIntrospection.convert()` produces deeply nested Maps). Same root cause as APPSEC-62784 — `ephemeralLease` elided from GC OopMap by JIT before JNI safepoint — but frees `PWArgsSegment` (MAP entries array) instead of `StringsSegment` (string data).

This branch is based on `fix/reachability-fence-crash-jdk21-jdk25` (PR #198). **Merge PR #198 first.**

Jira ticket: [APPSEC-68682](https://datadoghq.atlassian.net/browse/APPSEC-68682)

### Description of the Change

Single file changed: `ReachabilityFenceTest.groovy`

- New test method uses 3 concurrent GC threads + 500 `runEphemeral()` iterations, consistent with sibling tests in PR #198
- `serverResponseBodyRuleset()` uses an impossible regex (`IMPOSSIBLE_APPSEC68682_MARKER`, min_length 30) so the result is always `DDWAF_OK` — the test asserts this per iteration
- Clears `ByteBufferSerializer.ArenaPool.INSTANCE.arenas` in `finally` to avoid stale arena bytes affecting subsequent tests

### Additional Notes

The original draft of this test used `ARACHNI_ATOM_V2_1` (targets `server.request.headers.no_cookies`) with ephemeral data at `server.response.body`. That combination causes `check_new_rule_targets()` to return false so `eval_rules()` is never called and the nested `PWArgsSegment` data is never read — the test would not reproduce the crash. The fix is the custom `serverResponseBodyRuleset()`.

Run with `./gradlew testGCRace -PuseZGC` (requires JDK 21+). The task sets `-XX:-TieredCompilation -XX:CompileThreshold=1` so no warmup phase is needed.

[APPSEC-68682]: https://datadoghq.atlassian.net/browse/APPSEC-68682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ