### PR TITLE
Update libddwaf to 2.0.1

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ defaults:
 env:
   buildType: RelWithDebInfo
   tempdir: ${{ github.workspace }}/build
-  libddwafVersion: 1.30.0
+  libddwafVersion: 2.0.1
 jobs:
   Spotless:
     name: spotless

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ repositories {
 }
 
 group 'io.sqreen'
-version '17.4.0'
+version '17.5.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/c/byte_buffer.c
+++ b/src/main/c/byte_buffer.c
@@ -7,9 +7,12 @@
  */
 
 #include <jni.h>
+#include <ddwaf.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 #include "common.h"
+#include "ddwaf_layout.h"
 #include "jni/com_datadog_ddwaf_ByteBufferSerializer.h"
 
 JNIEXPORT jlong JNICALL
@@ -21,5 +24,63 @@ Java_com_datadog_ddwaf_ByteBufferSerializer_getByteBufferAddress(JNIEnv *env,
     void *addr = JNI(GetDirectBufferAddress, bb);
     jlong ret;
     memcpy(&ret, &addr, sizeof ret);
+    return ret;
+}
+
+/*
+ * Class:     com_datadog_ddwaf_ByteBufferSerializer
+ * Method:    getNativeObjectLayout
+ * Signature: ()[I
+ *
+ * Reports the real layout of ddwaf_object / ddwaf_object_kv so that
+ * ByteBufferSerializer, which hand-rolls the very same layout in Java in order
+ * to serialize with no copies, can validate its constants at initialization
+ * time instead of trusting them blindly. Keep in sync with
+ * ByteBufferSerializer.checkNativeLayout().
+ */
+JNIEXPORT jintArray JNICALL
+Java_com_datadog_ddwaf_ByteBufferSerializer_getNativeObjectLayout(JNIEnv *env,
+                                                                  jclass clazz)
+{
+    (void) clazz;
+
+    const jint layout[] = {
+            (jint) sizeof(ddwaf_object),
+            (jint) sizeof(ddwaf_object_kv),
+            (jint) offsetof(ddwaf_object_kv, key),
+            (jint) offsetof(ddwaf_object_kv, val),
+            (jint) DDWAF_OBJ_OFF_TYPE,
+            (jint) DDWAF_OBJ_OFF_BOOL_VAL,
+            (jint) DDWAF_OBJ_OFF_NUM_VAL,
+            (jint) DDWAF_OBJ_OFF_STR_SIZE,
+            (jint) DDWAF_OBJ_OFF_STR_PTR,
+            (jint) DDWAF_OBJ_OFF_SSTR_SIZE,
+            (jint) DDWAF_OBJ_OFF_SSTR_DATA,
+            (jint) DDWAF_OBJ_SSTR_SIZE,
+            (jint) DDWAF_OBJ_OFF_CONTAINER_SIZE,
+            (jint) DDWAF_OBJ_OFF_CONTAINER_CAPACITY,
+            (jint) DDWAF_OBJ_OFF_CONTAINER_PTR,
+            (jint) DDWAF_OBJ_INVALID,
+            (jint) DDWAF_OBJ_NULL,
+            (jint) DDWAF_OBJ_BOOL,
+            (jint) DDWAF_OBJ_SIGNED,
+            (jint) DDWAF_OBJ_UNSIGNED,
+            (jint) DDWAF_OBJ_FLOAT,
+            (jint) DDWAF_OBJ_STRING,
+            (jint) DDWAF_OBJ_LITERAL_STRING,
+            (jint) DDWAF_OBJ_SMALL_STRING,
+            (jint) DDWAF_OBJ_ARRAY,
+            (jint) DDWAF_OBJ_MAP,
+    };
+    const jsize count = (jsize) (sizeof(layout) / sizeof(layout[0]));
+
+    jintArray ret = JNI(NewIntArray, count);
+    if (!ret) {
+        return NULL;
+    }
+    JNI(SetIntArrayRegion, ret, 0, count, layout);
+    if (JNI(ExceptionCheck)) {
+        return NULL;
+    }
     return ret;
 }

--- a/src/main/c/common.h
+++ b/src/main/c/common.h
@@ -21,6 +21,9 @@
 
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
+/* expands a string literal into the (pointer, length) pair libddwaf expects */
+#define LSTR(x) "" x, (uint32_t) (sizeof(x) - 1)
+
 extern jclass jcls_rte;
 extern jclass jcls_iae;
 extern jmethodID rte_constr_cause;

--- a/src/main/c/ddwaf_layout.h
+++ b/src/main/c/ddwaf_layout.h
@@ -1,0 +1,89 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog
+ * (https://www.datadoghq.com/). Copyright 2025 Datadog, Inc.
+ */
+
+/*
+ * Single source of truth for the ddwaf_object binary layout that
+ * ByteBufferSerializer replicates in Java in order to serialize WAF input
+ * without copies.
+ *
+ * libddwaf explicitly reserves the right to break the low-level C API on minor
+ * versions, and the layout is not part of any stability contract, so:
+ *
+ *  - the _Static_asserts below make a layout change a compile-time error here;
+ *  - byte_buffer.c exposes these very same offsets to Java through
+ *    ByteBufferSerializer.getNativeObjectLayout(), which is validated against
+ *    the Java-side constants when the native library is loaded.
+ */
+
+#ifndef DDWAF_LAYOUT_H
+#define DDWAF_LAYOUT_H
+
+#include <ddwaf.h>
+#include <stddef.h>
+
+#define DDWAF_OBJ_OFF_TYPE offsetof(ddwaf_object, type)
+#define DDWAF_OBJ_OFF_BOOL_VAL offsetof(ddwaf_object, via.b8.val)
+#define DDWAF_OBJ_OFF_NUM_VAL offsetof(ddwaf_object, via.i64.val)
+#define DDWAF_OBJ_OFF_STR_SIZE offsetof(ddwaf_object, via.str.size)
+#define DDWAF_OBJ_OFF_STR_PTR offsetof(ddwaf_object, via.str.ptr)
+#define DDWAF_OBJ_OFF_SSTR_SIZE offsetof(ddwaf_object, via.sstr.size)
+#define DDWAF_OBJ_OFF_SSTR_DATA offsetof(ddwaf_object, via.sstr.data)
+#define DDWAF_OBJ_OFF_CONTAINER_SIZE offsetof(ddwaf_object, via.array.size)
+#define DDWAF_OBJ_OFF_CONTAINER_CAPACITY                                       \
+    offsetof(ddwaf_object, via.array.capacity)
+#define DDWAF_OBJ_OFF_CONTAINER_PTR offsetof(ddwaf_object, via.array.ptr)
+
+/* The Java serializer writes both arrays and maps through the same offsets, so
+ * the two container structs must agree. */
+_Static_assert(offsetof(ddwaf_object, via.map.size) ==
+                               DDWAF_OBJ_OFF_CONTAINER_SIZE &&
+                       offsetof(ddwaf_object, via.map.capacity) ==
+                               DDWAF_OBJ_OFF_CONTAINER_CAPACITY &&
+                       offsetof(ddwaf_object, via.map.ptr) ==
+                               DDWAF_OBJ_OFF_CONTAINER_PTR,
+               "ddwaf_object map and array layouts diverged");
+
+/* Likewise for the integral/float scalars, all written at the same offset. */
+_Static_assert(offsetof(ddwaf_object, via.u64.val) == DDWAF_OBJ_OFF_NUM_VAL &&
+                       offsetof(ddwaf_object, via.f64.val) ==
+                               DDWAF_OBJ_OFF_NUM_VAL,
+               "ddwaf_object scalar layouts diverged");
+
+_Static_assert(sizeof(ddwaf_object) == 16, "sizeof(ddwaf_object) changed");
+_Static_assert(sizeof(ddwaf_object_kv) == 32,
+               "sizeof(ddwaf_object_kv) changed");
+_Static_assert(offsetof(ddwaf_object_kv, key) == 0,
+               "ddwaf_object_kv.key is no longer the first member");
+_Static_assert(offsetof(ddwaf_object_kv, val) == 16,
+               "ddwaf_object_kv.val moved");
+
+_Static_assert(DDWAF_OBJ_OFF_TYPE == 0, "ddwaf_object.type moved");
+_Static_assert(DDWAF_OBJ_OFF_BOOL_VAL == 1, "ddwaf_object bool value moved");
+_Static_assert(DDWAF_OBJ_OFF_NUM_VAL == 8, "ddwaf_object scalar value moved");
+_Static_assert(DDWAF_OBJ_OFF_STR_SIZE == 4, "ddwaf_object string size moved");
+_Static_assert(DDWAF_OBJ_OFF_STR_PTR == 8, "ddwaf_object string ptr moved");
+_Static_assert(DDWAF_OBJ_OFF_SSTR_SIZE == 1, "small string size moved");
+_Static_assert(DDWAF_OBJ_OFF_SSTR_DATA == 2, "small string data moved");
+_Static_assert(DDWAF_OBJ_SSTR_SIZE == 14, "small string capacity changed");
+_Static_assert(DDWAF_OBJ_OFF_CONTAINER_SIZE == 2, "container size moved");
+_Static_assert(DDWAF_OBJ_OFF_CONTAINER_CAPACITY == 4,
+               "container capacity moved");
+_Static_assert(DDWAF_OBJ_OFF_CONTAINER_PTR == 8, "container ptr moved");
+
+/* DDWAF_OBJ_TYPE values are a bitmask, mirrored verbatim in
+ * ByteBufferSerializer.PWInputType. */
+_Static_assert(DDWAF_OBJ_INVALID == 0x00 && DDWAF_OBJ_NULL == 0x01 &&
+                       DDWAF_OBJ_BOOL == 0x02 && DDWAF_OBJ_SIGNED == 0x04 &&
+                       DDWAF_OBJ_UNSIGNED == 0x06 && DDWAF_OBJ_FLOAT == 0x08 &&
+                       DDWAF_OBJ_STRING == 0x10 &&
+                       DDWAF_OBJ_LITERAL_STRING == 0x12 &&
+                       DDWAF_OBJ_SMALL_STRING == 0x14 &&
+                       DDWAF_OBJ_ARRAY == 0x20 && DDWAF_OBJ_MAP == 0x40,
+               "DDWAF_OBJ_TYPE values changed");
+
+#endif // DDWAF_LAYOUT_H

--- a/src/main/c/debug_helpers.c
+++ b/src/main/c/debug_helpers.c
@@ -29,6 +29,7 @@ JNIEXPORT jstring JNICALL
 Java_com_datadog_ddwaf_Waf_pwArgsBufferToString(JNIEnv *, jclass, jobject);
 
 static void _hstring_write_pwargs(hstring *str, size_t depth,
+                                  const ddwaf_object *key,
                                   const ddwaf_object *pwargs);
 
 /*
@@ -53,7 +54,7 @@ JNIEXPORT jstring JNICALL Java_com_datadog_ddwaf_Waf_pwArgsBufferToString(
     if (!str.buffer) {
         return NULL;
     }
-    _hstring_write_pwargs(&str, 0, &root);
+    _hstring_write_pwargs(&str, 0, NULL, &root);
 #ifdef __clang_analyzer__
     // due to other exclusions, analyzer doesn't know str.buffer was written
     jstring jstr = NULL;
@@ -130,18 +131,37 @@ static void _hstring_repeat(hstring *str, char c, size_t repeat_times)
 }
 
 static void _hstring_write_pwargs(hstring *str, size_t depth,
+                                  const ddwaf_object *key,
                                   const ddwaf_object *pwargs)
 {
-    if (depth > 25) { // arbitrary cutoff to avoid stackoverflows
+    if (depth > 25 || pwargs == NULL) { // arbitrary cutoff to avoid
+                                        // stackoverflows
         return;
     }
     _hstring_repeat(str, ' ', depth * 2);
-    if (pwargs->parameterName) {
-        _hstring_append(str, pwargs->parameterName,
-                        pwargs->parameterNameLength);
+    if (key != NULL && ddwaf_object_is_string(key)) {
+        size_t key_len;
+        const char *key_str = ddwaf_object_get_string(key, &key_len);
+        if (key_str) {
+            _hstring_append(str, key_str, key_len);
+        }
         HSTRING_APPEND_CONST(str, ": ");
     }
-    switch (pwargs->type) {
+
+    // small and literal strings are printed like regular strings; the
+    // distinction is a storage detail
+    if (ddwaf_object_is_string(pwargs)) {
+        HSTRING_APPEND_CONST(str, "<STRING> ");
+        size_t len;
+        const char *value = ddwaf_object_get_string(pwargs, &len);
+        if (value) {
+            _hstring_append(str, value, len);
+        }
+        HSTRING_APPEND_CONST(str, "\n");
+        return;
+    }
+
+    switch (ddwaf_object_get_type(pwargs)) {
     case DDWAF_OBJ_INVALID:
         HSTRING_APPEND_CONST(str, "<INVALID>\n");
         break;
@@ -152,7 +172,7 @@ static void _hstring_write_pwargs(hstring *str, size_t depth,
         HSTRING_APPEND_CONST(str, "<SIGNED> ");
         char scratch[sizeof("-9223372036854775808")];
         int len = snprintf(scratch, sizeof(scratch), "%" PRId64,
-                           pwargs->intValue);
+                           ddwaf_object_get_signed(pwargs));
         if ((size_t) len < sizeof scratch) {
             _hstring_append(str, scratch, (size_t) len);
         } // else should never happen
@@ -163,51 +183,53 @@ static void _hstring_write_pwargs(hstring *str, size_t depth,
         HSTRING_APPEND_CONST(str, "<UNSIGNED> ");
         char scratch[sizeof("18446744073709551615")];
         int len = snprintf(scratch, sizeof(scratch), "%" PRIu64,
-                           pwargs->uintValue);
+                           ddwaf_object_get_unsigned(pwargs));
         if ((size_t) len < sizeof scratch) {
             _hstring_append(str, scratch, (size_t) len);
         } // else should never happen
         HSTRING_APPEND_CONST(str, "\n");
         break;
     }
-    case DDWAF_OBJ_FLOAT:
+    case DDWAF_OBJ_FLOAT: {
         HSTRING_APPEND_CONST(str, "<FLOAT> ");
         char scratch[sizeof("6.324040266767955765e-322")];
-        int len = snprintf(scratch, sizeof(scratch), "%.18e", pwargs->f64);
+        int len = snprintf(scratch, sizeof(scratch), "%.18e",
+                           ddwaf_object_get_float(pwargs));
         if ((size_t) len < sizeof scratch) {
             _hstring_append(str, scratch, (size_t) len);
         } // else should never happen
         HSTRING_APPEND_CONST(str, "\n");
         break;
+    }
     case DDWAF_OBJ_BOOL:
         HSTRING_APPEND_CONST(str, "<BOOL> ");
-        if (pwargs->boolean) {
+        if (ddwaf_object_get_bool(pwargs)) {
             HSTRING_APPEND_CONST(str, "true\n");
         } else {
             HSTRING_APPEND_CONST(str, "false\n");
         }
         break;
-    case DDWAF_OBJ_STRING:
-        HSTRING_APPEND_CONST(str, "<STRING> ");
-        _hstring_append(str, pwargs->stringValue, pwargs->nbEntries);
-        HSTRING_APPEND_CONST(str, "\n");
-        break;
     case DDWAF_OBJ_ARRAY: {
         HSTRING_APPEND_CONST(str, "<ARRAY>\n");
-        for (size_t i = 0; i < pwargs->nbEntries; i++) {
-            _hstring_write_pwargs(str, depth + 1, pwargs->array + i);
+        size_t size = ddwaf_object_get_size(pwargs);
+        for (size_t i = 0; i < size; i++) {
+            _hstring_write_pwargs(str, depth + 1, NULL,
+                                  ddwaf_object_at_value(pwargs, i));
         }
         break;
+    }
     case DDWAF_OBJ_MAP: {
         HSTRING_APPEND_CONST(str, "<MAP>\n");
-        for (size_t i = 0; i < pwargs->nbEntries; i++) {
-            _hstring_write_pwargs(str, depth + 1, pwargs->array + i);
+        size_t size = ddwaf_object_get_size(pwargs);
+        for (size_t i = 0; i < size; i++) {
+            _hstring_write_pwargs(str, depth + 1,
+                                  ddwaf_object_at_key(pwargs, i),
+                                  ddwaf_object_at_value(pwargs, i));
         }
         break;
     }
     default:
         HSTRING_APPEND_CONST(str, "<UNKNOWN>\n");
         break;
-    }
     }
 }

--- a/src/main/c/debug_helpers.c
+++ b/src/main/c/debug_helpers.c
@@ -28,9 +28,13 @@ typedef struct {
 JNIEXPORT jstring JNICALL
 Java_com_datadog_ddwaf_Waf_pwArgsBufferToString(JNIEnv *, jclass, jobject);
 
+JNIEXPORT jstring JNICALL
+Java_com_datadog_ddwaf_Waf_referenceObjectTreeToString(JNIEnv *, jclass);
+
 static void _hstring_write_pwargs(hstring *str, size_t depth,
                                   const ddwaf_object *key,
                                   const ddwaf_object *pwargs);
+static jstring _pwargs_to_jstring(JNIEnv *env, const ddwaf_object *root);
 
 /*
  * Class:     com.datadog.ddwaf.Waf
@@ -49,12 +53,68 @@ JNIEXPORT jstring JNICALL Java_com_datadog_ddwaf_Waf_pwArgsBufferToString(
 
     ddwaf_object root;
     memcpy(&root, input_p, sizeof root);
+    return _pwargs_to_jstring(env, &root);
+}
+
+/*
+ * Class:     com.datadog.ddwaf.Waf
+ * Method:    referenceObjectTreeToString
+ * Signature: ()Ljava/lang/String;
+ *
+ * (FOR TESTING PURPOSES ONLY) Builds a fixed object tree using libddwaf's
+ * official ddwaf_object_set_* and ddwaf_object_insert_* API and renders it with
+ * the same printer used for pwArgsBufferToString. The Java side builds the
+ * equivalent tree with ByteBufferSerializer's hand-rolled layout and compares
+ * the two renderings, which detects any divergence between the two
+ * construction paths.
+ */
+JNIEXPORT jstring JNICALL
+Java_com_datadog_ddwaf_Waf_referenceObjectTreeToString(JNIEnv *env,
+                                                       jclass clazz)
+{
+    (void) clazz;
+    ddwaf_allocator alloc = ddwaf_get_default_allocator();
+
+    ddwaf_object root;
+    ddwaf_object_set_map(&root, 8, alloc);
+
+    ddwaf_object_set_string(ddwaf_object_insert_key(&root, LSTR("sstr"), alloc),
+                            LSTR("small"), alloc);
+    ddwaf_object_set_string(ddwaf_object_insert_key(&root, LSTR("str"), alloc),
+                            LSTR("a string longer than 14 bytes"), alloc);
+    ddwaf_object_set_signed(
+            ddwaf_object_insert_key(&root, LSTR("signed"), alloc), -42);
+    ddwaf_object_set_bool(ddwaf_object_insert_key(&root, LSTR("bool"), alloc),
+                          true);
+    ddwaf_object_set_float(ddwaf_object_insert_key(&root, LSTR("float"), alloc),
+                           8.5);
+    ddwaf_object_set_null(ddwaf_object_insert_key(&root, LSTR("null"), alloc));
+
+    ddwaf_object *arr = ddwaf_object_insert_key(&root, LSTR("array"), alloc);
+    ddwaf_object_set_array(arr, 2, alloc);
+    ddwaf_object_set_signed(ddwaf_object_insert(arr, alloc), 1);
+    ddwaf_object_set_string(ddwaf_object_insert(arr, alloc), LSTR("two"),
+                            alloc);
+
+    ddwaf_object *nested = ddwaf_object_insert_key(&root, LSTR("map"), alloc);
+    ddwaf_object_set_map(nested, 1, alloc);
+    ddwaf_object_set_string(
+            ddwaf_object_insert_key(nested, LSTR("inner"), alloc),
+            LSTR("value"), alloc);
+
+    jstring jstr = _pwargs_to_jstring(env, &root);
+    ddwaf_object_destroy(&root, alloc);
+    return jstr;
+}
+
+static jstring _pwargs_to_jstring(JNIEnv *env, const ddwaf_object *root)
+{
     hstring str = {.buffer = malloc(INITIAL_CAPACITY),
                    .capacity = INITIAL_CAPACITY};
     if (!str.buffer) {
         return NULL;
     }
-    _hstring_write_pwargs(&str, 0, NULL, &root);
+    _hstring_write_pwargs(&str, 0, NULL, root);
 #ifdef __clang_analyzer__
     // due to other exclusions, analyzer doesn't know str.buffer was written
     jstring jstr = NULL;

--- a/src/main/c/jni/com_datadog_ddwaf_ByteBufferSerializer.h
+++ b/src/main/c/jni/com_datadog_ddwaf_ByteBufferSerializer.h
@@ -10,11 +10,48 @@ extern "C" {
 #undef com_datadog_ddwaf_ByteBufferSerializer_NULLPTR
 #define com_datadog_ddwaf_ByteBufferSerializer_NULLPTR 0LL
 #undef com_datadog_ddwaf_ByteBufferSerializer_SIZEOF_PWARGS
-#define com_datadog_ddwaf_ByteBufferSerializer_SIZEOF_PWARGS 40L
+#define com_datadog_ddwaf_ByteBufferSerializer_SIZEOF_PWARGS 16L
+#undef com_datadog_ddwaf_ByteBufferSerializer_SIZEOF_PWARGS_KV
+#define com_datadog_ddwaf_ByteBufferSerializer_SIZEOF_PWARGS_KV 32L
+#undef com_datadog_ddwaf_ByteBufferSerializer_OFF_KV_VALUE
+#define com_datadog_ddwaf_ByteBufferSerializer_OFF_KV_VALUE 16L
+#undef com_datadog_ddwaf_ByteBufferSerializer_OFF_TYPE
+#define com_datadog_ddwaf_ByteBufferSerializer_OFF_TYPE 0L
+#undef com_datadog_ddwaf_ByteBufferSerializer_OFF_BOOL_VAL
+#define com_datadog_ddwaf_ByteBufferSerializer_OFF_BOOL_VAL 1L
+#undef com_datadog_ddwaf_ByteBufferSerializer_OFF_NUM_VAL
+#define com_datadog_ddwaf_ByteBufferSerializer_OFF_NUM_VAL 8L
+#undef com_datadog_ddwaf_ByteBufferSerializer_OFF_STR_SIZE
+#define com_datadog_ddwaf_ByteBufferSerializer_OFF_STR_SIZE 4L
+#undef com_datadog_ddwaf_ByteBufferSerializer_OFF_STR_PTR
+#define com_datadog_ddwaf_ByteBufferSerializer_OFF_STR_PTR 8L
+#undef com_datadog_ddwaf_ByteBufferSerializer_OFF_SSTR_SIZE
+#define com_datadog_ddwaf_ByteBufferSerializer_OFF_SSTR_SIZE 1L
+#undef com_datadog_ddwaf_ByteBufferSerializer_OFF_SSTR_DATA
+#define com_datadog_ddwaf_ByteBufferSerializer_OFF_SSTR_DATA 2L
+#undef com_datadog_ddwaf_ByteBufferSerializer_OFF_CONTAINER_SIZE
+#define com_datadog_ddwaf_ByteBufferSerializer_OFF_CONTAINER_SIZE 2L
+#undef com_datadog_ddwaf_ByteBufferSerializer_OFF_CONTAINER_CAPACITY
+#define com_datadog_ddwaf_ByteBufferSerializer_OFF_CONTAINER_CAPACITY 4L
+#undef com_datadog_ddwaf_ByteBufferSerializer_OFF_CONTAINER_PTR
+#define com_datadog_ddwaf_ByteBufferSerializer_OFF_CONTAINER_PTR 8L
+#undef com_datadog_ddwaf_ByteBufferSerializer_MAX_SMALL_STRING_SIZE
+#define com_datadog_ddwaf_ByteBufferSerializer_MAX_SMALL_STRING_SIZE 14L
+#undef com_datadog_ddwaf_ByteBufferSerializer_MAX_CONTAINER_SIZE
+#define com_datadog_ddwaf_ByteBufferSerializer_MAX_CONTAINER_SIZE 65535L
 #undef com_datadog_ddwaf_ByteBufferSerializer_PWARGS_MIN_SEGMENTS_SIZE
 #define com_datadog_ddwaf_ByteBufferSerializer_PWARGS_MIN_SEGMENTS_SIZE 512L
 #undef com_datadog_ddwaf_ByteBufferSerializer_STRINGS_MIN_SEGMENTS_SIZE
 #define com_datadog_ddwaf_ByteBufferSerializer_STRINGS_MIN_SEGMENTS_SIZE 81920L
+/*
+ * Class:     com_datadog_ddwaf_ByteBufferSerializer
+ * Method:    getNativeObjectLayout
+ * Signature: ()[I
+ */
+JNIEXPORT jintArray JNICALL
+Java_com_datadog_ddwaf_ByteBufferSerializer_getNativeObjectLayout(JNIEnv *,
+                                                                  jclass);
+
 /*
  * Class:     com_datadog_ddwaf_ByteBufferSerializer
  * Method:    getByteBufferAddress

--- a/src/main/c/jni/com_datadog_ddwaf_Waf.h
+++ b/src/main/c/jni/com_datadog_ddwaf_Waf.h
@@ -17,6 +17,14 @@ Java_com_datadog_ddwaf_Waf_pwArgsBufferToString(JNIEnv *, jclass, jobject);
 
 /*
  * Class:     com_datadog_ddwaf_Waf
+ * Method:    referenceObjectTreeToString
+ * Signature: ()Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_com_datadog_ddwaf_Waf_referenceObjectTreeToString(JNIEnv *, jclass);
+
+/*
+ * Class:     com_datadog_ddwaf_Waf
  * Method:    getVersion
  * Signature: ()Ljava/lang/String;
  */

--- a/src/main/c/output.c
+++ b/src/main/c/output.c
@@ -9,6 +9,7 @@
 #include "output.h"
 #include <assert.h>
 #include <ddwaf.h>
+#include <math.h>
 #include <stdint.h>
 #include <string.h>
 #include <inttypes.h>
@@ -23,7 +24,6 @@
 #include "base64.h"
 #include "logging.h"
 
-#define LSTR(x) "" x, sizeof(x) - 1
 #define MAX_JINT ((jint) 0x7FFFFFFF)
 
 static struct j_method _rsi_init;
@@ -53,13 +53,13 @@ static struct json_segment *_convert_json(const ddwaf_object *cur_obj,
                                           int depth,
                                           struct json_segment *cur_seg);
 
-static bool _is_derivative(const ddwaf_object *entry, const char *prefix)
+static bool _key_has_prefix(const char *key, size_t key_len, const char *prefix)
 {
     size_t prefix_size = strlen(prefix);
-    if (entry->parameterNameLength < prefix_size) {
+    if (key == NULL || key_len < prefix_size) {
         return false;
     }
-    return strncmp(prefix, entry->parameterName, prefix_size) == 0;
+    return strncmp(prefix, key, prefix_size) == 0;
 }
 
 static bool _cache_single_class_strong(JNIEnv *env, const char *class_name,
@@ -289,19 +289,12 @@ static const ddwaf_object *_map_get_object_checked(JNIEnv *env,
                                                    const char *str,
                                                    size_t str_len)
 {
-    if (!obj || obj->type != DDWAF_OBJ_MAP) {
+    if (!obj || !ddwaf_object_is_map(obj)) {
         JNI(ThrowNew, jcls_rte, "ddwaf map expected");
         return NULL;
     }
 
-    for (uint64_t i = 0; i < obj->nbEntries; i++) {
-        const ddwaf_object *o = &obj->array[i];
-        if (o->parameterNameLength == str_len &&
-            memcmp(o->parameterName, str, str_len) == 0) {
-            return o;
-        }
-    }
-    return NULL;
+    return ddwaf_object_find(obj, str, str_len);
 }
 
 static jstring _map_get_string_checked(JNIEnv *env, const ddwaf_object *obj,
@@ -328,28 +321,29 @@ static jobject _convert_strarr_checked(JNIEnv *env, const ddwaf_object *o)
         return NULL;
     }
 
-    if (o->type != DDWAF_OBJ_ARRAY) {
+    if (!ddwaf_object_is_array(o)) {
         JNI(ThrowNew, jcls_rte, "ddwaf array expected");
         return NULL;
     }
 
-    if (o->nbEntries == 0) {
+    size_t nb_entries = ddwaf_object_get_size(o);
+    if (nb_entries == 0) {
         return NULL;
     }
 
-    if (o->nbEntries > MAX_JINT) {
+    if (nb_entries > MAX_JINT) {
         JNI(ThrowNew, jcls_rte, "too many elements in ddwaf array");
         return NULL;
     }
 
     jobject ret =
-            java_meth_call(env, &_array_list_init, NULL, (jint) o->nbEntries);
+            java_meth_call(env, &_array_list_init, NULL, (jint) nb_entries);
     if (ret == NULL) {
         return NULL;
     }
 
-    for (uint64_t i = 0; i < o->nbEntries; i++) {
-        const ddwaf_object *elem = &o->array[i];
+    for (size_t i = 0; i < nb_entries; i++) {
+        const ddwaf_object *elem = ddwaf_object_at_value(o, i);
         size_t str_len;
         const char *str = ddwaf_object_get_string(elem, &str_len);
         if (!str) {
@@ -397,12 +391,13 @@ static jobject _map_get_object_errmap_checked(JNIEnv *env,
         return NULL;
     }
 
-    if (o->type != DDWAF_OBJ_MAP) {
+    if (!ddwaf_object_is_map(o)) {
         JNI(ThrowNew, jcls_rte, "ddwaf map expected");
         return NULL;
     }
 
-    if (o->nbEntries == 0) {
+    size_t nb_entries = ddwaf_object_get_size(o);
+    if (nb_entries == 0) {
         return NULL;
     }
 
@@ -411,15 +406,23 @@ static jobject _map_get_object_errmap_checked(JNIEnv *env,
         return NULL;
     }
 
-    for (uint64_t i = 0; i < o->nbEntries; i++) {
-        ddwaf_object *elem = &o->array[i];
-        if (elem->type != DDWAF_OBJ_ARRAY) {
+    for (size_t i = 0; i < nb_entries; i++) {
+        const ddwaf_object *elem = ddwaf_object_at_value(o, i);
+        if (!ddwaf_object_is_array(elem)) {
             JNI(ThrowNew, jcls_rte, "ddwaf array expected inside map");
             goto err;
         }
 
-        jstring jkey = java_utf8_to_jstring_checked(env, elem->parameterName,
-                                                    elem->parameterNameLength);
+        /* ddwaf_object_get_string leaves key_len untouched for a non-string
+         * key, so treat such a key as the empty string */
+        size_t key_len = 0;
+        const char *key_str =
+                ddwaf_object_get_string(ddwaf_object_at_key(o, i), &key_len);
+        if (key_str == NULL) {
+            key_str = "";
+            key_len = 0;
+        }
+        jstring jkey = java_utf8_to_jstring_checked(env, key_str, key_len);
         if (JNI(ExceptionCheck)) {
             goto err;
         }
@@ -536,65 +539,93 @@ static struct json_segment *_convert_json(const ddwaf_object *cur_obj,
         return NULL;
     }
 
-    switch (cur_obj->type) {
+    if (ddwaf_object_is_string(cur_obj)) {
+        size_t len;
+        const char *value = ddwaf_object_get_string(cur_obj, &len);
+        cur_seg = json_append(cur_seg, "\"", 1);
+        cur_seg = json_encode_str(cur_seg, value, len);
+        cur_seg = json_append(cur_seg, "\"", 1);
+        return cur_seg;
+    }
+
+    switch (ddwaf_object_get_type(cur_obj)) {
     case DDWAF_OBJ_INVALID:
-        return false;
+        return NULL;
+    case DDWAF_OBJ_NULL:
+        cur_seg = json_append(cur_seg, "null", 4);
+        break;
     case DDWAF_OBJ_SIGNED: {
-        int64_t val = cur_obj->intValue;
         char str[21];
-        int len = sprintf(str, "%" PRId64, val);
+        int len = sprintf(str, "%" PRId64, ddwaf_object_get_signed(cur_obj));
         assert(len > 0); // can't fail
         cur_seg = json_append(cur_seg, str, (size_t) len);
     } break;
     case DDWAF_OBJ_UNSIGNED: {
-        uint64_t val = cur_obj->uintValue;
         char str[21];
-        int len = sprintf(str, "%" PRIu64, val);
+        int len = sprintf(str, "%" PRIu64, ddwaf_object_get_unsigned(cur_obj));
         assert(len > 0); // can't fail
         cur_seg = json_append(cur_seg, str, (size_t) len);
     } break;
-    case DDWAF_OBJ_STRING: {
-        cur_seg = json_append(cur_seg, "\"", 1);
-        cur_seg = json_encode_str(cur_seg, cur_obj->stringValue,
-                                  cur_obj->nbEntries);
-        cur_seg = json_append(cur_seg, "\"", 1);
+    case DDWAF_OBJ_FLOAT: {
+        double value = ddwaf_object_get_float(cur_obj);
+        if (!isfinite(value)) {
+            /* infinities and NaN have no JSON representation */
+            cur_seg = json_append(cur_seg, "null", 4);
+            break;
+        }
+        char str[32];
+        int len = snprintf(str, sizeof(str), "%.17g", value);
+        assert(len > 0 && (size_t) len < sizeof(str)); // can't fail
+        cur_seg = json_append(cur_seg, str, (size_t) len);
     } break;
     case DDWAF_OBJ_ARRAY: {
+        size_t nb_entries = ddwaf_object_get_size(cur_obj);
         cur_seg = json_append(cur_seg, "[", 1);
-        for (uint64_t i = 0; i < cur_obj->nbEntries; i++) {
-            const ddwaf_object *o = &cur_obj->array[i];
-            cur_seg = _convert_json(o, depth + 1, cur_seg);
-            if (i != cur_obj->nbEntries - 1) {
+        for (size_t i = 0; i < nb_entries; i++) {
+            cur_seg = _convert_json(ddwaf_object_at_value(cur_obj, i),
+                                    depth + 1, cur_seg);
+            if (i != nb_entries - 1) {
                 cur_seg = json_append(cur_seg, ",", 1);
             }
         }
         cur_seg = json_append(cur_seg, "]", 1);
     } break;
     case DDWAF_OBJ_MAP: {
+        size_t nb_entries = ddwaf_object_get_size(cur_obj);
         cur_seg = json_append(cur_seg, "{", 1);
-        for (uint64_t i = 0; i < cur_obj->nbEntries; i++) {
-            const ddwaf_object *o = &cur_obj->array[i];
+        for (size_t i = 0; i < nb_entries; i++) {
+            /* ddwaf_object_get_string leaves key_len untouched for a non-string
+             * key, so treat such a key as the empty string */
+            size_t key_len = 0;
+            const char *key_str = ddwaf_object_get_string(
+                    ddwaf_object_at_key(cur_obj, i), &key_len);
+            if (key_str == NULL) {
+                key_str = "";
+                key_len = 0;
+            }
 
             cur_seg = json_append(cur_seg, "\"", 1);
-            cur_seg = json_encode_str(cur_seg, o->parameterName,
-                                      o->parameterNameLength);
+            cur_seg = json_encode_str(cur_seg, key_str, key_len);
             cur_seg = json_append(cur_seg, "\":", 2);
 
-            cur_seg = _convert_json(o, depth + 1, cur_seg);
+            cur_seg = _convert_json(ddwaf_object_at_value(cur_obj, i),
+                                    depth + 1, cur_seg);
 
-            if (i != cur_obj->nbEntries - 1) {
+            if (i != nb_entries - 1) {
                 cur_seg = json_append(cur_seg, ",", 1);
             }
         }
         cur_seg = json_append(cur_seg, "}", 1);
     } break;
     case DDWAF_OBJ_BOOL: {
-        if (cur_obj->boolean) {
+        if (ddwaf_object_get_bool(cur_obj)) {
             cur_seg = json_append(cur_seg, "true", 4);
         } else {
             cur_seg = json_append(cur_seg, "false", 5);
         }
     } break;
+    default:
+        return NULL;
     }
 
     return cur_seg;
@@ -702,51 +733,58 @@ static jstring _encode_json_gzip_base64_checked(JNIEnv *env,
 
 jobject output_convert_attributes_checked(JNIEnv *env, const ddwaf_object *obj)
 {
-    assert(obj->type == DDWAF_OBJ_MAP);
+    assert(ddwaf_object_is_map(obj));
 
     jobject ret = java_meth_call(env, &_linked_hm_init, NULL);
     if (JNI(ExceptionCheck)) {
         return NULL;
     }
 
-    for (size_t i = 0; i < obj->nbEntries; i++) {
-        ddwaf_object *entry = &obj->array[i];
-        jstring key = java_utf8_to_jstring_checked(env, entry->parameterName,
-                                                   entry->parameterNameLength);
+    size_t nb_entries = ddwaf_object_get_size(obj);
+    for (size_t i = 0; i < nb_entries; i++) {
+        const ddwaf_object *entry = ddwaf_object_at_value(obj, i);
+        /* ddwaf_object_get_string leaves key_len untouched for a non-string
+         * key, so treat such a key as the empty string */
+        size_t key_len = 0;
+        const char *key_str =
+                ddwaf_object_get_string(ddwaf_object_at_key(obj, i), &key_len);
+        if (key_str == NULL) {
+            key_str = "";
+            key_len = 0;
+        }
+        jstring key = java_utf8_to_jstring_checked(env, key_str, key_len);
         if (JNI(ExceptionCheck)) {
             goto error;
         }
 
+        DDWAF_OBJ_TYPE entry_type = ddwaf_object_get_type(entry);
         jobject value = NULL;
-        if (_is_derivative(entry, "_dd.appsec.s.")) {
+        if (_key_has_prefix(key_str, key_len, "_dd.appsec.s.")) {
             // json schemas are json that has to be gzipped and encoded in
             // base64
             value = _encode_json_gzip_base64_checked(env, entry);
-        } else if (_is_derivative(entry, "_dd.appsec.fp.")) {
-            // fingerprints are simple strings
-            value = java_utf8_to_jstring_checked(env, entry->stringValue,
-                                                 entry->nbEntries);
-        } else if (entry->type == DDWAF_OBJ_STRING) {
-            // general string attributes
-            value = java_utf8_to_jstring_checked(env, entry->stringValue,
-                                                 entry->nbEntries);
-        } else if (entry->type == DDWAF_OBJ_SIGNED) {
+        } else if (ddwaf_object_is_string(entry)) {
+            // fingerprints (_dd.appsec.fp.*) and general string attributes
+            size_t str_len;
+            const char *str_val = ddwaf_object_get_string(entry, &str_len);
+            value = java_utf8_to_jstring_checked(env, str_val, str_len);
+        } else if (entry_type == DDWAF_OBJ_SIGNED) {
             // signed integer attributes
             value = java_meth_call(env, &long_valueOf, long_cls,
-                                   (jlong) entry->intValue);
-        } else if (entry->type == DDWAF_OBJ_UNSIGNED) {
+                                   (jlong) ddwaf_object_get_signed(entry));
+        } else if (entry_type == DDWAF_OBJ_UNSIGNED) {
             // unsigned integer attributes
             value = java_meth_call(env, &long_valueOf, long_cls,
-                                   (jlong) entry->uintValue);
-        } else if (entry->type == DDWAF_OBJ_FLOAT) {
+                                   (jlong) ddwaf_object_get_unsigned(entry));
+        } else if (entry_type == DDWAF_OBJ_FLOAT) {
             // float/double attributes
             value = java_meth_call(env, &double_valueOf, double_cls,
-                                   (jdouble) entry->f64);
-        } else if (entry->type == DDWAF_OBJ_BOOL) {
+                                   (jdouble) ddwaf_object_get_float(entry));
+        } else if (entry_type == DDWAF_OBJ_BOOL) {
             // boolean attributes
             value = java_meth_call(env, &boolean_valueOf, boolean_cls,
-                                   (jboolean) entry->boolean);
-        } else if (entry->type == DDWAF_OBJ_MAP) {
+                                   (jboolean) ddwaf_object_get_bool(entry));
+        } else if (entry_type == DDWAF_OBJ_MAP) {
             // map-type attributes (like trace tagging objects)
             jobject map_value = convert_ddwaf_object_to_jobject(env, entry);
             if (JNI(ExceptionCheck)) {
@@ -768,8 +806,8 @@ jobject output_convert_attributes_checked(JNIEnv *env, const ddwaf_object *obj)
             goto error;
         } else if (value == NULL) {
             JAVA_LOG(DDWAF_LOG_DEBUG,
-                     "Failed serializing derivative entry for %*.s",
-                     (int) entry->parameterNameLength, entry->parameterName);
+                     "Failed serializing derivative entry for %.*s",
+                     (int) key_len, key_str);
             JNI(DeleteLocalRef, key);
             continue;
         }
@@ -791,38 +829,45 @@ error:
 
 jobject convert_ddwaf_object_to_jobject(JNIEnv *env, const ddwaf_object *obj)
 {
-    switch (obj->type) {
+    if (ddwaf_object_is_string(obj)) {
+        size_t str_len;
+        const char *str_val = ddwaf_object_get_string(obj, &str_len);
+        return java_utf8_to_jstring_checked(env, str_val, str_len);
+    }
+
+    switch (ddwaf_object_get_type(obj)) {
     case DDWAF_OBJ_INVALID:
         JNI(ThrowNew, jcls_rte, "Unsupported ddwaf object type");
         return NULL;
+    case DDWAF_OBJ_NULL:
+        return NULL;
     case DDWAF_OBJ_SIGNED:
         return java_meth_call(env, &long_valueOf, long_cls,
-                              (jlong) obj->intValue);
+                              (jlong) ddwaf_object_get_signed(obj));
     case DDWAF_OBJ_UNSIGNED:
         return java_meth_call(env, &long_valueOf, long_cls,
-                              (jlong) obj->uintValue);
+                              (jlong) ddwaf_object_get_unsigned(obj));
     case DDWAF_OBJ_FLOAT:
         return java_meth_call(env, &double_valueOf, double_cls,
-                              (jdouble) obj->f64);
+                              (jdouble) ddwaf_object_get_float(obj));
     case DDWAF_OBJ_BOOL:
         return java_meth_call(env, &boolean_valueOf, boolean_cls,
-                              (jboolean) obj->boolean);
-    case DDWAF_OBJ_STRING:
-        return java_utf8_to_jstring_checked(env, obj->stringValue,
-                                            obj->nbEntries);
+                              (jboolean) ddwaf_object_get_bool(obj));
     case DDWAF_OBJ_ARRAY: {
-        if (obj->nbEntries > MAX_JINT) {
+        size_t nb_entries = ddwaf_object_get_size(obj);
+        if (nb_entries > MAX_JINT) {
             JNI(ThrowNew, jcls_rte, "Too many elements in ddwaf array");
             return NULL;
         }
-        jobject ret = java_meth_call(env, &_array_list_init, NULL,
-                                     (jint) obj->nbEntries);
+        jobject ret =
+                java_meth_call(env, &_array_list_init, NULL, (jint) nb_entries);
         if (ret == NULL) {
             return NULL;
         }
 
-        for (uint64_t i = 0; i < obj->nbEntries; i++) {
-            jobject elem = convert_ddwaf_object_to_jobject(env, &obj->array[i]);
+        for (size_t i = 0; i < nb_entries; i++) {
+            jobject elem = convert_ddwaf_object_to_jobject(
+                    env, ddwaf_object_at_value(obj, i));
             if (JNI(ExceptionCheck)) {
                 JNI(DeleteLocalRef, ret);
                 return NULL;
@@ -844,16 +889,25 @@ jobject convert_ddwaf_object_to_jobject(JNIEnv *env, const ddwaf_object *obj)
             return NULL;
         }
 
-        for (uint64_t i = 0; i < obj->nbEntries; i++) {
-            ddwaf_object *elem = &obj->array[i];
-            jstring key = java_utf8_to_jstring_checked(
-                    env, elem->parameterName, elem->parameterNameLength);
+        size_t nb_entries = ddwaf_object_get_size(obj);
+        for (size_t i = 0; i < nb_entries; i++) {
+            /* ddwaf_object_get_string leaves key_len untouched for a non-string
+             * key, so treat such a key as the empty string */
+            size_t key_len = 0;
+            const char *key_str = ddwaf_object_get_string(
+                    ddwaf_object_at_key(obj, i), &key_len);
+            if (key_str == NULL) {
+                key_str = "";
+                key_len = 0;
+            }
+            jstring key = java_utf8_to_jstring_checked(env, key_str, key_len);
             if (JNI(ExceptionCheck)) {
                 JNI(DeleteLocalRef, ret);
                 return NULL;
             }
 
-            jobject value = convert_ddwaf_object_to_jobject(env, elem);
+            jobject value = convert_ddwaf_object_to_jobject(
+                    env, ddwaf_object_at_value(obj, i));
             if (JNI(ExceptionCheck)) {
                 JNI(DeleteLocalRef, key);
                 return NULL;
@@ -870,6 +924,8 @@ jobject convert_ddwaf_object_to_jobject(JNIEnv *env, const ddwaf_object *obj)
 
         return ret;
     }
+    default:
+        break;
     }
     JNI(ThrowNew, jcls_rte, "Unknown ddwaf object type");
     return NULL;

--- a/src/main/c/output.c
+++ b/src/main/c/output.c
@@ -53,6 +53,22 @@ static struct json_segment *_convert_json(const ddwaf_object *cur_obj,
                                           int depth,
                                           struct json_segment *cur_seg);
 
+/* Reads the key of the index-th entry of the map container as a string.
+ * ddwaf_object_get_string leaves the length untouched for a non-string key, so
+ * such a key is reported as the empty string. */
+static const char *_key_string(const ddwaf_object *container, size_t index,
+                               size_t *len)
+{
+    *len = 0;
+    const char *key_str =
+            ddwaf_object_get_string(ddwaf_object_at_key(container, index), len);
+    if (key_str == NULL) {
+        key_str = "";
+        *len = 0;
+    }
+    return key_str;
+}
+
 static bool _key_has_prefix(const char *key, size_t key_len, const char *prefix)
 {
     size_t prefix_size = strlen(prefix);
@@ -413,15 +429,8 @@ static jobject _map_get_object_errmap_checked(JNIEnv *env,
             goto err;
         }
 
-        /* ddwaf_object_get_string leaves key_len untouched for a non-string
-         * key, so treat such a key as the empty string */
-        size_t key_len = 0;
-        const char *key_str =
-                ddwaf_object_get_string(ddwaf_object_at_key(o, i), &key_len);
-        if (key_str == NULL) {
-            key_str = "";
-            key_len = 0;
-        }
+        size_t key_len;
+        const char *key_str = _key_string(o, i, &key_len);
         jstring jkey = java_utf8_to_jstring_checked(env, key_str, key_len);
         if (JNI(ExceptionCheck)) {
             goto err;
@@ -594,15 +603,8 @@ static struct json_segment *_convert_json(const ddwaf_object *cur_obj,
         size_t nb_entries = ddwaf_object_get_size(cur_obj);
         cur_seg = json_append(cur_seg, "{", 1);
         for (size_t i = 0; i < nb_entries; i++) {
-            /* ddwaf_object_get_string leaves key_len untouched for a non-string
-             * key, so treat such a key as the empty string */
-            size_t key_len = 0;
-            const char *key_str = ddwaf_object_get_string(
-                    ddwaf_object_at_key(cur_obj, i), &key_len);
-            if (key_str == NULL) {
-                key_str = "";
-                key_len = 0;
-            }
+            size_t key_len;
+            const char *key_str = _key_string(cur_obj, i, &key_len);
 
             cur_seg = json_append(cur_seg, "\"", 1);
             cur_seg = json_encode_str(cur_seg, key_str, key_len);
@@ -743,15 +745,8 @@ jobject output_convert_attributes_checked(JNIEnv *env, const ddwaf_object *obj)
     size_t nb_entries = ddwaf_object_get_size(obj);
     for (size_t i = 0; i < nb_entries; i++) {
         const ddwaf_object *entry = ddwaf_object_at_value(obj, i);
-        /* ddwaf_object_get_string leaves key_len untouched for a non-string
-         * key, so treat such a key as the empty string */
-        size_t key_len = 0;
-        const char *key_str =
-                ddwaf_object_get_string(ddwaf_object_at_key(obj, i), &key_len);
-        if (key_str == NULL) {
-            key_str = "";
-            key_len = 0;
-        }
+        size_t key_len;
+        const char *key_str = _key_string(obj, i, &key_len);
         jstring key = java_utf8_to_jstring_checked(env, key_str, key_len);
         if (JNI(ExceptionCheck)) {
             goto error;
@@ -891,15 +886,8 @@ jobject convert_ddwaf_object_to_jobject(JNIEnv *env, const ddwaf_object *obj)
 
         size_t nb_entries = ddwaf_object_get_size(obj);
         for (size_t i = 0; i < nb_entries; i++) {
-            /* ddwaf_object_get_string leaves key_len untouched for a non-string
-             * key, so treat such a key as the empty string */
-            size_t key_len = 0;
-            const char *key_str = ddwaf_object_get_string(
-                    ddwaf_object_at_key(obj, i), &key_len);
-            if (key_str == NULL) {
-                key_str = "";
-                key_len = 0;
-            }
+            size_t key_len;
+            const char *key_str = _key_string(obj, i, &key_len);
             jstring key = java_utf8_to_jstring_checked(env, key_str, key_len);
             if (JNI(ExceptionCheck)) {
                 JNI(DeleteLocalRef, ret);

--- a/src/main/c/waf_jni.c
+++ b/src/main/c/waf_jni.c
@@ -20,6 +20,9 @@
 #include "metrics.h"
 #include "cs_wrapper.h"
 #include "compat.h"
+/* no symbol of ddwaf_layout.h is used here; it is included for its
+ * _Static_asserts, which pin the ddwaf_object layout this file relies on */
+#include "ddwaf_layout.h"
 #include <ddwaf.h>
 #include <assert.h>
 #ifndef _MSC_VER
@@ -57,8 +60,9 @@ struct _init_or_update {
     jobject jspec;
     jobjectArray jrsi_arr;
 };
-static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
-                                     struct _limits *limits, int rec_level);
+static void _convert_checked(JNIEnv *env, ddwaf_object *out, jobject obj,
+                             struct _limits *limits, int rec_level,
+                             ddwaf_allocator alloc);
 static ddwaf_object *_convert_buffer_checked(JNIEnv *env, jobject buffer);
 static struct _limits _fetch_limits_checked(JNIEnv *env, jobject limits_obj);
 struct char_buffer_info {
@@ -86,18 +90,24 @@ static void _throw_pwaf_exception(JNIEnv *env, DDWAF_RET_CODE retcode);
 static void _throw_pwaf_timeout_exception(JNIEnv *env);
 static void _update_metrics(JNIEnv *env, jobject metrics_obj,
                             const ddwaf_object *ret);
-static bool _convert_ddwaf_config_checked(JNIEnv *env, jobject jconfig,
-                                          ddwaf_config *out_config);
-static void _dispose_of_ddwaf_config(ddwaf_config *cfg);
+static bool _apply_obfuscator_config_checked(JNIEnv *env, ddwaf_builder builder,
+                                             jobject jconfig);
 static jobject _create_result_checked(JNIEnv *env, DDWAF_RET_CODE code,
                                       const ddwaf_object *ddwaf_result);
-static inline bool _has_events(const ddwaf_object *res);
-static void consume_json_and_free(const ddwaf_object *obj);
+static uint64_t _get_duration(const ddwaf_object *res);
 
-#define MAX_DEPTH_UPPER_LIMIT ((uint32_t) 32)
+/* Container size/capacity are uint16_t in libddwaf 2.x. */
+#define MAX_CONTAINER_SIZE ((int) UINT16_MAX)
 
-// don't use DDWAF_OBJ_INVALID, as that can't be added to arrays/maps
-static const ddwaf_object _pwinput_invalid = {.type = DDWAF_OBJ_MAP};
+/* The path under which the obfuscator regexes given through WafConfig are
+ * registered in the builder. In libddwaf 2.x ddwaf_config is gone and the
+ * obfuscator is configured like any other piece of configuration. */
+#define OBFUSCATOR_CONFIG_PATH "libddwaf-java/obfuscator"
+
+/* Default per-run timeout in microseconds, overridable through the
+ * DD_APPSEC_WAF_TIMEOUT system property. libddwaf used to export this as
+ * DDWAF_RUN_TIMEOUT, but that macro was removed in 2.0. */
+#define DDWAF_RUN_TIMEOUT 5000
 
 jclass jcls_rte;
 jclass jcls_iae;
@@ -433,7 +443,12 @@ JNIEXPORT jlong JNICALL Java_com_datadog_ddwaf_WafContext_initWafContext(
         return 0L;
     }
 
-    ddwaf_context context = ddwaf_context_init(nat_handle);
+    /* The output allocator serves the result objects handed back by
+     * ddwaf_context_eval / ddwaf_subcontext_eval and must outlive the context.
+     * The default allocator is a process-wide singleton, so it trivially does.
+     */
+    ddwaf_context context =
+            ddwaf_context_init(nat_handle, ddwaf_get_default_allocator());
     if (!context) {
         JNI(ThrowNew, jcls_rte, "ddwaf_context_init failed");
         return 0L;
@@ -454,7 +469,10 @@ static jobject _run_waf_context_common(JNIEnv *env, jobject this,
     ddwaf_object *ephemeral_input_ptr = NULL;
 
     struct _limits limits;
+    /* on DDWAF_ERR_INTERNAL libddwaf leaves the result untouched, so make sure
+     * it is always safe to inspect and destroy */
     ddwaf_object ddwaf_result;
+    ddwaf_object_set_invalid(&ddwaf_result);
     struct timespec start;
 
     if (!_get_time_checked(env, &start)) {
@@ -477,11 +495,6 @@ static jobject _run_waf_context_common(JNIEnv *env, jobject this,
 
     context = _get_waf_context_context_checked(env, this);
     if (!context) {
-        return NULL;
-    }
-
-    if (context == 0) {
-        JNI(ThrowNew, jcls_rte, "The WafContext has already been cleared");
         return NULL;
     }
 
@@ -515,6 +528,18 @@ static jobject _run_waf_context_common(JNIEnv *env, jobject this,
         return NULL;
     }
 
+    /* libddwaf 2.x has no combined persistent+ephemeral evaluation: ephemeral
+     * data is now evaluated through a subcontext, which produces its own
+     * result. Mixing both in a single call would mean merging two result
+     * objects, so the caller must issue two separate calls instead. */
+    if (persistent_input_ptr != NULL && ephemeral_input_ptr != NULL) {
+        JAVA_LOG(DDWAF_LOG_WARN,
+                 "Persistent and ephemeral data cannot be evaluated in the "
+                 "same call; use separate run()/runEphemeral() calls");
+        _throw_pwaf_exception(env, DDWAF_ERR_INVALID_ARGUMENT);
+        return NULL;
+    }
+
     struct timespec conv_end;
     if (!_get_time_checked(env, &conv_end)) {
         goto err;
@@ -533,15 +558,39 @@ static jobject _run_waf_context_common(JNIEnv *env, jobject this,
 
     size_t run_budget = get_run_budget(rem_gen_budget_in_us, &limits);
 
-    DDWAF_RET_CODE ret_code =
-            ddwaf_run(context, persistent_input_ptr, ephemeral_input_ptr,
-                      &ddwaf_result, run_budget);
-    const ddwaf_object *timeout =
-            ddwaf_object_find(&ddwaf_result, "timeout", 7);
-    if (timeout != NULL && timeout->type == DDWAF_OBJ_BOOL &&
-        ddwaf_object_get_bool(timeout)) {
-        _throw_pwaf_timeout_exception(env);
-        goto freeRet;
+    /* alloc = NULL means libddwaf only takes a view of the data: it neither
+     * copies nor frees it. This is the exact replacement of the removed
+     * ddwaf_config.free_fn = NULL and is what keeps the serialization
+     * zero-copy. The direct ByteBuffer backing the data must therefore stay
+     * alive for as long as the context (or the subcontext) does; see the
+     * reachability fence in WafContext.java. */
+    DDWAF_RET_CODE ret_code;
+    if (ephemeral_input_ptr != NULL) {
+        /* ephemerals are subcontexts in libddwaf 2.x: the subcontext inherits
+         * the persistent data of the parent context, and the data given to it
+         * does not outlive the subcontext */
+        ddwaf_subcontext subcontext = ddwaf_subcontext_init(context);
+        if (!subcontext) {
+            JNI(ThrowNew, jcls_rte, "ddwaf_subcontext_init failed");
+            return NULL;
+        }
+        ret_code = ddwaf_subcontext_eval(subcontext, ephemeral_input_ptr, NULL,
+                                         &ddwaf_result, run_budget);
+        ddwaf_subcontext_destroy(subcontext);
+    } else {
+        ret_code = ddwaf_context_eval(context, persistent_input_ptr, NULL,
+                                      &ddwaf_result, run_budget);
+    }
+
+    if (ret_code == DDWAF_OK || ret_code == DDWAF_MATCH) {
+        const ddwaf_object *timeout =
+                ddwaf_object_find(&ddwaf_result, LSTR("timeout"));
+        if (timeout != NULL &&
+            ddwaf_object_get_type(timeout) == DDWAF_OBJ_BOOL &&
+            ddwaf_object_get_bool(timeout)) {
+            _throw_pwaf_timeout_exception(env);
+            goto freeRet;
+        }
     }
 
     switch (ret_code) {
@@ -566,7 +615,9 @@ static jobject _run_waf_context_common(JNIEnv *env, jobject this,
 
 freeRet:
     _update_metrics(env, metrics_obj, &ddwaf_result);
-    ddwaf_object_free(&ddwaf_result);
+    /* the result was allocated with the output allocator given to
+     * ddwaf_context_init, not with the (NULL) input allocator */
+    ddwaf_object_destroy(&ddwaf_result, ddwaf_get_default_allocator());
 
     return result;
 
@@ -980,15 +1031,17 @@ Java_com_datadog_ddwaf_WafBuilder_addOrUpdateConfigNative(
     }
 
     jobject result_diagnostics = NULL;
+    ddwaf_allocator alloc = ddwaf_get_default_allocator();
     ddwaf_object ddwaf_diagnostics;
-    ddwaf_object_invalid(&ddwaf_diagnostics);
+    ddwaf_object_set_invalid(&ddwaf_diagnostics);
     struct _limits limits = {
             .max_depth = 20,
             .max_elements = 1000000,
             .max_string_size = 1000000,
     };
-    ddwaf_object ddwaf_configuration =
-            _convert_checked(env, configuration, &limits, 0);
+    ddwaf_object ddwaf_configuration;
+    _convert_checked(env, &ddwaf_configuration, configuration, &limits, 0,
+                     alloc);
     if (JNI(ExceptionCheck)) {
         goto error;
     }
@@ -1009,7 +1062,7 @@ Java_com_datadog_ddwaf_WafBuilder_addOrUpdateConfigNative(
             ddwaf_builder, path_string, path_length, &ddwaf_configuration,
             &ddwaf_diagnostics);
 
-    if (ddwaf_object_type(&ddwaf_diagnostics) != DDWAF_OBJ_INVALID) {
+    if (ddwaf_object_get_type(&ddwaf_diagnostics) != DDWAF_OBJ_INVALID) {
         result_diagnostics =
                 output_convert_diagnostics_checked(env, &ddwaf_diagnostics);
 
@@ -1031,8 +1084,9 @@ error:
     if (result_diagnostics) {
         JNI(DeleteLocalRef, result_diagnostics);
     }
-    ddwaf_object_free(&ddwaf_configuration);
-    ddwaf_object_free(&ddwaf_diagnostics);
+    ddwaf_object_destroy(&ddwaf_configuration, alloc);
+    /* diagnostics are always served by the default allocator */
+    ddwaf_object_destroy(&ddwaf_diagnostics, ddwaf_get_default_allocator());
     return result;
 }
 
@@ -1040,14 +1094,18 @@ JNIEXPORT jlong JNICALL Java_com_datadog_ddwaf_WafBuilder_initBuilder(
         JNIEnv *env, jclass clazz, jobject config)
 {
     UNUSED(clazz);
-    ddwaf_config ddwaf_configuration;
-    _convert_ddwaf_config_checked(env, config, &ddwaf_configuration);
-    if (JNI(ExceptionCheck)) {
-        JAVA_LOG(DDWAF_LOG_DEBUG, "config was not found in ddwaf");
+
+    ddwaf_builder builder = ddwaf_builder_init();
+    if (!builder) {
+        JNI(ThrowNew, jcls_rte, "ddwaf_builder_init failed");
         return 0L;
     }
-    ddwaf_builder builder = ddwaf_builder_init(&ddwaf_configuration);
-    _dispose_of_ddwaf_config(&ddwaf_configuration);
+
+    if (!_apply_obfuscator_config_checked(env, builder, config)) {
+        ddwaf_builder_destroy(builder);
+        return 0L;
+    }
+
     return (jlong) (intptr_t) builder;
 }
 
@@ -1384,8 +1442,27 @@ static void _dispose_of_cache_references(JNIEnv *env)
     _dispose_of_cached_methods(env);
 }
 
-static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
-                                     struct _limits *lims, int rec_level)
+/* clamps a container size to what libddwaf's uint16_t capacity can hold */
+static uint16_t _clamp_capacity(jsize len)
+{
+    if (len < 0) {
+        return 0;
+    }
+    if (len > MAX_CONTAINER_SIZE) {
+        return (uint16_t) MAX_CONTAINER_SIZE;
+    }
+    return (uint16_t) len;
+}
+
+/*
+ * Converts a Java object into a ddwaf_object written in place into *out, using
+ * the official libddwaf construction API. This path is only used for the
+ * (infrequent) builder configuration; request data goes through the zero-copy
+ * ByteBufferSerializer instead.
+ */
+static void _convert_checked(JNIEnv *env, ddwaf_object *out, jobject obj,
+                             struct _limits *lims, int rec_level,
+                             ddwaf_allocator alloc)
 {
 #define RET_IF_EXC()                                                           \
     do {                                                                       \
@@ -1413,18 +1490,17 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
      * 1) maximum depth exceeded or
      * 2) a java method call or another JNI calls throws.
      *
-     * It particular, it doesn't "fail" if any of the Waf_* functions
-     * fail. It never checks their return values. The assumption is that
-     * any failure will be an extraordinary circumstance and that the
-     * implementation is designed in such a way that passing NULL pointers
-     * or PWI_INVALID objects doesn't cause crashes */
+     * It particular, it doesn't "fail" if any of the ddwaf_object_* functions
+     * fail. It never checks their return values, except where a NULL would
+     * have to be dereferenced. The assumption is that any failure will be an
+     * extraordinary circumstance. */
+
+    ddwaf_object_set_invalid(out);
 
     if (rec_level > lims->max_depth) {
         JNI(ThrowNew, jcls_rte, "Maximum recursion level exceeded");
         goto error;
     }
-
-    ddwaf_object result = _pwinput_invalid;
 
     jboolean is_array = JNI_FALSE;
     if (obj != NULL) {
@@ -1437,11 +1513,13 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
     }
 
     if (JNI(IsSameObject, obj, NULL)) {
-        ddwaf_object_null(&result); // can't fail
+        ddwaf_object_set_null(out);
     } else if (is_array == JNI_TRUE) {
-        ddwaf_object_array(&result); // can't fail
+        jsize len = JNI(GetArrayLength, obj);
+        bool too_deep = rec_level >= lims->max_depth;
+        ddwaf_object_set_array(out, too_deep ? 0 : _clamp_capacity(len), alloc);
 
-        if (rec_level >= lims->max_depth) {
+        if (too_deep) {
             JAVA_LOG(DDWAF_LOG_INFO,
                      "Leaving array empty because max depth of %d "
                      "has been reached",
@@ -1449,33 +1527,44 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
             goto early_return;
         }
 
-        jsize len = JNI(GetArrayLength, obj);
-
+        int inserted = 0;
         for (int i = 0; i < len; i++) {
-
             if (lims->max_elements <= 0) {
                 JAVA_LOG(DDWAF_LOG_INFO, "Interrupting iterating array due to "
                                          "the max of elements being reached");
                 break;
             }
+            if (inserted >= MAX_CONTAINER_SIZE) {
+                JAVA_LOG(DDWAF_LOG_INFO,
+                         "Interrupting iterating array due to the maximum "
+                         "container size of %d being reached",
+                         MAX_CONTAINER_SIZE);
+                break;
+            }
 
             jobject element = JNI(GetObjectArrayElement, obj, i);
-
-            ddwaf_object value =
-                    _convert_checked(env, element, lims, rec_level + 1);
-            if (JNI(ExceptionCheck)) {
+            ddwaf_object *slot = ddwaf_object_insert(out, alloc);
+            if (!slot) {
+                JNI(DeleteLocalRef, element);
+                JNI(ThrowNew, jcls_rte, "ddwaf_object_insert failed (OOM?)");
                 goto error;
             }
-            bool success = ddwaf_object_array_add(&result, &value);
+            inserted++;
+
+            _convert_checked(env, slot, element, lims, rec_level + 1, alloc);
             JNI(DeleteLocalRef, element);
-            if (!success) {
-                JNI(ThrowNew, jcls_rte, "ddwaf_object_array_add failed (OOM?)");
+            if (JNI(ExceptionCheck)) {
                 goto error;
             }
         }
     } else if (JNI(IsInstanceOf, obj, *map_cls)) {
-        ddwaf_object_map(&result); // can't fail
-        if (rec_level >= lims->max_depth) {
+        bool too_deep = rec_level >= lims->max_depth;
+        jint map_len = JNI(CallIntMethod, obj, map_size.meth_id);
+        if (JNI(ExceptionCheck)) {
+            goto error;
+        }
+        ddwaf_object_set_map(out, too_deep ? 0 : _clamp_capacity(map_len), alloc);
+        if (too_deep) {
             JAVA_LOG(DDWAF_LOG_DEBUG,
                      "Leaving map empty because max depth of %d "
                      "has been reached",
@@ -1487,6 +1576,7 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
         JAVA_CALL(entry_set, map_entryset, obj);
         JAVA_CALL(entry_set_it, iterable_iterator, entry_set);
 
+        int inserted = 0;
         while (JNI(CallBooleanMethod, entry_set_it, iterator_hasNext.meth_id)) {
             if (JNI(ExceptionCheck)) {
                 goto error;
@@ -1495,6 +1585,13 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
                 JAVA_LOG(DDWAF_LOG_DEBUG,
                          "Interrupting map iteration due to the max "
                          "number of elements being reached");
+                break;
+            }
+            if (inserted >= MAX_CONTAINER_SIZE) {
+                JAVA_LOG(DDWAF_LOG_INFO,
+                         "Interrupting map iteration due to the maximum "
+                         "container size of %d being reached",
+                         MAX_CONTAINER_SIZE);
                 break;
             }
 
@@ -1510,12 +1607,6 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
             JNI(DeleteLocalRef, key_obj);
             JNI(DeleteLocalRef, entry);
 
-            ddwaf_object value =
-                    _convert_checked(env, value_obj, lims, rec_level + 1);
-            if (JNI(ExceptionCheck)) {
-                goto error;
-            }
-
             size_t key_len;
             char *key_cstr = java_to_utf8_limited_checked(
                     env, key_jstr, &key_len, lims->max_string_size);
@@ -1523,17 +1614,24 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
                 goto error;
             }
 
-            bool success =
-                    ddwaf_object_map_addl(&result, key_cstr, key_len, &value);
+            ddwaf_object *slot = ddwaf_object_insert_key(
+                    out, key_cstr, (uint32_t) key_len, alloc);
             free(key_cstr);
+            if (!slot) {
+                JNI(ThrowNew, jcls_rte,
+                    "ddwaf_object_insert_key failed (OOM?)");
+                goto error;
+            }
+            inserted++;
+
+            _convert_checked(env, slot, value_obj, lims, rec_level + 1, alloc);
 
             /* doesn't matter if these leak in case of error
              * we do need to delete them in normal circumstances because we're
              * on a loop and we don't want to run out of local refs */
             JNI(DeleteLocalRef, value_obj);
             JNI(DeleteLocalRef, key_jstr);
-            if (!success) {
-                JNI(ThrowNew, jcls_rte, "ddwaf_object_map_add failed (OOM?)");
+            if (JNI(ExceptionCheck)) {
                 goto error;
             }
         }
@@ -1542,8 +1640,13 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
         JNI(DeleteLocalRef, entry_set);
 
     } else if (JNI(IsInstanceOf, obj, *iterable_cls)) {
-        ddwaf_object_array(&result);
-        if (rec_level >= lims->max_depth) {
+        bool too_deep = rec_level >= lims->max_depth;
+        /* Iterable (unlike Map/array) doesn't expose a size accessor; the
+         * only way to know the element count is to exhaust the iterator,
+         * so we can't pre-size the capacity here and rely on
+         * ddwaf_object_insert growing the backing storage as needed. */
+        ddwaf_object_set_array(out, 0, alloc);
+        if (too_deep) {
             JAVA_LOG(DDWAF_LOG_DEBUG,
                      "Leaving array empty because max depth of %d "
                      "has been reached",
@@ -1553,6 +1656,7 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
 
         jobject it;
         JAVA_CALL(it, iterable_iterator, obj);
+        int inserted = 0;
         while (JNI(CallBooleanMethod, it, iterator_hasNext.meth_id)) {
             if (JNI(ExceptionCheck)) {
                 goto error;
@@ -1563,20 +1667,28 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
                          "the max of elements being reached");
                 break;
             }
+            if (inserted >= MAX_CONTAINER_SIZE) {
+                JAVA_LOG(DDWAF_LOG_INFO,
+                         "Interrupting iterable iteration due to the maximum "
+                         "container size of %d being reached",
+                         MAX_CONTAINER_SIZE);
+                break;
+            }
 
             jobject element;
             JAVA_CALL(element, iterator_next, it);
 
-            ddwaf_object value =
-                    _convert_checked(env, element, lims, rec_level + 1);
-            if (JNI(ExceptionCheck)) {
+            ddwaf_object *slot = ddwaf_object_insert(out, alloc);
+            if (!slot) {
+                JNI(DeleteLocalRef, element);
+                JNI(ThrowNew, jcls_rte, "ddwaf_object_insert failed (OOM?)");
                 goto error;
             }
+            inserted++;
 
-            bool success = ddwaf_object_array_add(&result, &value);
+            _convert_checked(env, slot, element, lims, rec_level + 1, alloc);
             JNI(DeleteLocalRef, element);
-            if (!success) {
-                JNI(ThrowNew, jcls_rte, "ddwaf_object_array_add failed (OOM?)");
+            if (JNI(ExceptionCheck)) {
                 goto error;
             }
         }
@@ -1591,10 +1703,11 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
             goto error;
         }
 
-        bool success = !!ddwaf_object_stringl(&result, str_c, len);
+        bool success =
+                !!ddwaf_object_set_string(out, str_c, (uint32_t) len, alloc);
         free(str_c);
         if (!success) {
-            JNI(ThrowNew, jcls_rte, "ddwaf_object_stringl failed (OOM?)");
+            JNI(ThrowNew, jcls_rte, "ddwaf_object_set_string failed (OOM?)");
             goto error;
         }
 
@@ -1629,11 +1742,12 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
                 goto error;
             }
 
-            bool success = !!ddwaf_object_stringl(&result, (char *) utf8_out,
-                                                  utf8_len);
+            bool success = !!ddwaf_object_set_string(
+                    out, (char *) utf8_out, (uint32_t) utf8_len, alloc);
             free(utf8_out);
             if (!success) {
-                JNI(ThrowNew, jcls_rte, "ddwaf_object_stringl failed (OOM?)");
+                JNI(ThrowNew, jcls_rte,
+                    "ddwaf_object_set_string failed (OOM?)");
                 goto error;
             }
         } else { // regular char sequence or non-direct CharBuffer w/out array
@@ -1668,10 +1782,12 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
                 goto error;
             }
 
-            bool success = !!ddwaf_object_stringl(&result, utf8_out, utf8_len);
+            bool success = !!ddwaf_object_set_string(
+                    out, utf8_out, (uint32_t) utf8_len, alloc);
             free(utf8_out);
             if (!success) {
-                JNI(ThrowNew, jcls_rte, "ddwaf_object_stringl failed (OOM?)");
+                JNI(ThrowNew, jcls_rte,
+                    "ddwaf_object_set_string failed (OOM?)");
                 goto error;
             }
         }
@@ -1685,17 +1801,17 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
             if (JNI(ExceptionCheck)) {
                 goto error;
             }
-            success = !!ddwaf_object_float(&result, dval);
+            success = !!ddwaf_object_set_float(out, dval);
         } else {
             jlong lval = JNI(CallLongMethod, obj, number_longValue.meth_id);
             if (JNI(ExceptionCheck)) {
                 goto error;
             }
-            success = !!ddwaf_object_signed(&result, lval);
+            success = !!ddwaf_object_set_signed(out, lval);
         }
 
         if (!success) {
-            JNI(ThrowNew, jcls_rte, "ddwaf_object_signed failed");
+            JNI(ThrowNew, jcls_rte, "ddwaf_object_set_signed failed");
             goto error;
         }
     } else if (JNI(IsInstanceOf, obj, *_boolean_cls)) {
@@ -1706,46 +1822,50 @@ static ddwaf_object _convert_checked(JNIEnv *env, jobject obj,
             goto error;
         }
 
-        if (!ddwaf_object_bool(&result, (bool) bval)) {
-            JNI(ThrowNew, jcls_rte, "ddwaf_object_bool failed (OOM?)");
+        if (!ddwaf_object_set_bool(out, (bool) bval)) {
+            JNI(ThrowNew, jcls_rte, "ddwaf_object_set_bool failed (OOM?)");
             goto error;
         }
-    } else if (log_level_enabled(DDWAF_LOG_DEBUG)) {
-        jclass cls = JNI(GetObjectClass, obj);
-        jobject name = java_meth_call(env, &_class_get_name, cls);
-        static const char unknown[] = "<unknown class>";
-        static const size_t unknown_len = sizeof(unknown) - 1;
-        const char *name_c;
-        size_t name_len;
-        if (JNI(ExceptionCheck)) {
-            JNI(ExceptionClear);
-            name_c = unknown;
-            name_len = unknown_len;
-        } else {
-            name_c = java_to_utf8_checked(env, (jstring) name, &name_len);
+    } else {
+        if (log_level_enabled(DDWAF_LOG_DEBUG)) {
+            jclass cls = JNI(GetObjectClass, obj);
+            jobject name = java_meth_call(env, &_class_get_name, cls);
+            static const char unknown[] = "<unknown class>";
+            static const size_t unknown_len = sizeof(unknown) - 1;
+            const char *name_c;
+            size_t name_len;
             if (JNI(ExceptionCheck)) {
                 JNI(ExceptionClear);
                 name_c = unknown;
                 name_len = unknown_len;
+            } else {
+                name_c = java_to_utf8_checked(env, (jstring) name, &name_len);
+                if (JNI(ExceptionCheck)) {
+                    JNI(ExceptionClear);
+                    name_c = unknown;
+                    name_len = unknown_len;
+                }
+            }
+
+            JAVA_LOG(DDWAF_LOG_DEBUG,
+                     "Could not convert object of type %.*s; "
+                     "encoding as an empty map",
+                     (int) name_len /* should be safe */, name_c);
+            if (name_c != unknown) {
+                free((void *) (uintptr_t) name_c);
             }
         }
-
-        JAVA_LOG(DDWAF_LOG_DEBUG,
-                 "Could not convert object of type %.*s; "
-                 "encoding as invalid",
-                 (int) name_len /* should be safe */, name_c);
-        if (name_c != unknown) {
-            free((void *) (uintptr_t) name_c);
-        }
+        /* an invalid object cannot be stored in a container, so fall back to an
+         * empty map, as the pre-2.0 code did */
+        ddwaf_object_set_map(out, 0, alloc);
     }
 
-    // having lael here so if we add cleanup in the future we don't forget
+    // having label here so if we add cleanup in the future we don't forget
 early_return:
-    return result;
+    return;
 error:
-    ddwaf_object_free(&result);
-
-    return _pwinput_invalid;
+    ddwaf_object_destroy(out, alloc);
+    ddwaf_object_set_map(out, 0, alloc);
 }
 
 static ddwaf_object *_convert_buffer_checked(JNIEnv *env, jobject buffer)
@@ -1898,7 +2018,7 @@ static struct _limits _fetch_limits_checked(JNIEnv *env, jobject limits_obj)
 
     return l;
 error:
-    return (struct _limits){0};
+    return (struct _limits) {0};
 }
 
 static bool _get_time_checked(JNIEnv *env, struct timespec *time)
@@ -2058,14 +2178,8 @@ static void _update_metrics(JNIEnv *env, jobject metrics_obj,
 
     // metrics update
     if (!JNI(IsSameObject, metrics_obj, NULL)) {
-        // Get duration from the ddwaf_object structure
-        const ddwaf_object *duration_obj =
-                ddwaf_object_find(ddwaf_result, "duration", 8);
-        jlong duration = 0;
-        if (duration_obj != NULL && duration_obj->type == DDWAF_OBJ_UNSIGNED) {
-            duration = (jlong) ddwaf_object_get_unsigned(duration_obj);
-        }
-        metrics_update_checked(env, metrics_obj, 0, duration);
+        metrics_update_checked(env, metrics_obj, 0,
+                               (jlong) _get_duration(ddwaf_result));
     }
 
     if (earlier_exc) {
@@ -2085,86 +2199,112 @@ static void _update_metrics(JNIEnv *env, jobject metrics_obj,
     }
 }
 
-static bool _convert_ddwaf_config_checked(JNIEnv *env, jobject jconfig,
-                                          ddwaf_config *out_config)
+/*
+ * Registers the obfuscator regexes of a WafConfig in the builder.
+ *
+ * libddwaf 2.x removed ddwaf_config; the obfuscator is now provided like any
+ * other configuration, as {obfuscator: {key_regex: ..., value_regex: ...}}.
+ * Note that an *absent* key means "use libddwaf's built-in default", while an
+ * *empty* one means "do not obfuscate" — which is why both keys are always
+ * written, even when empty. This preserves the semantics of the old
+ * ddwaf_config.obfuscator, where a NULL regex disabled obfuscation.
+ */
+static bool _apply_obfuscator_config_checked(JNIEnv *env, ddwaf_builder builder,
+                                             jobject jconfig)
 {
+    bool ret = false;
+    char *key_regex = NULL, *value_regex = NULL;
+    size_t key_regex_len = 0, value_regex_len = 0;
 
     if (JNI(IsSameObject, jconfig, NULL)) {
         JNI(ThrowNew, jcls_iae, "Waf config cannot be null");
-        return false;
+        goto end;
     }
-
-    char *key_regex = NULL, *value_regex = NULL;
 
     jobject key_regex_jstr = JNI(GetObjectField, jconfig, _config_key_regex);
     if (JNI(ExceptionCheck)) {
-        return false;
+        goto end;
     }
     if (!JNI(IsSameObject, key_regex_jstr, NULL)) {
         key_regex = java_to_utf8_checked(env, (jstring) key_regex_jstr,
-                                         &(size_t){0});
+                                         &key_regex_len);
         if (!key_regex) {
-            return false;
-        }
-        if (key_regex[0] == '\0') {
-            free(key_regex);
-            key_regex = NULL;
+            goto end;
         }
     }
+
     jobject value_regex_jstr =
             JNI(GetObjectField, jconfig, _config_value_regex);
     if (JNI(ExceptionCheck)) {
-        return false;
+        goto end;
     }
     if (!JNI(IsSameObject, value_regex_jstr, NULL)) {
         value_regex = java_to_utf8_checked(env, (jstring) value_regex_jstr,
-                                           &(size_t){0});
+                                           &value_regex_len);
         if (!value_regex) {
-            free(key_regex);
-            return false;
-        }
-        if (value_regex[0] == '\0') {
-            free(value_regex);
-            value_regex = NULL;
+            goto end;
         }
     }
 
-    *out_config = (ddwaf_config){
-            // disable these checks. We also have our own
-            // limits given at rule run time
-            .limits =
-                    {// libddwaf allocates a vector with this
-                     // size, so this can't be too large
-                     .max_container_depth = MAX_DEPTH_UPPER_LIMIT,
-                     .max_container_size = (uint32_t) -1,
-                     .max_string_length = (uint32_t) -1},
+    ddwaf_allocator alloc = ddwaf_get_default_allocator();
+    ddwaf_object config;
+    ddwaf_object_set_map(&config, 1, alloc);
+    ddwaf_object *obfuscator =
+            ddwaf_object_insert_literal_key(&config, LSTR("obfuscator"), alloc);
+    if (!obfuscator || !ddwaf_object_set_map(obfuscator, 2, alloc)) {
+        ddwaf_object_destroy(&config, alloc);
+        JNI(ThrowNew, jcls_rte, "Failed building the obfuscator configuration");
+        goto end;
+    }
+    /* a missing key would silently fall back to libddwaf's default regex, so
+     * the insertions must be checked */
+    ddwaf_object *key_regex_slot = ddwaf_object_insert_literal_key(
+            obfuscator, LSTR("key_regex"), alloc);
+    ddwaf_object *value_regex_slot = ddwaf_object_insert_literal_key(
+            obfuscator, LSTR("value_regex"), alloc);
+    if (!key_regex_slot || !value_regex_slot) {
+        ddwaf_object_destroy(&config, alloc);
+        JNI(ThrowNew, jcls_rte, "Failed building the obfuscator configuration");
+        goto end;
+    }
+    ddwaf_object_set_string(key_regex_slot, key_regex ? key_regex : "",
+                            (uint32_t) key_regex_len, alloc);
+    ddwaf_object_set_string(value_regex_slot, value_regex ? value_regex : "",
+                            (uint32_t) value_regex_len, alloc);
 
-            .obfuscator =
-                    {
-                            .key_regex = key_regex,
-                            .value_regex = value_regex,
-                    },
+    bool added = ddwaf_builder_add_or_update_config(
+            builder, LSTR(OBFUSCATOR_CONFIG_PATH), &config, NULL);
+    ddwaf_object_destroy(&config, alloc);
+    if (!added) {
+        JNI(ThrowNew, jcls_rte, "Failed to configure the WAF obfuscator");
+        goto end;
+    }
 
-            .free_fn = NULL};
-
-    return true;
-}
-static void _dispose_of_ddwaf_config(ddwaf_config *cfg)
-{
-    free((void *) (uintptr_t) cfg->obfuscator.key_regex);
-    free((void *) (uintptr_t) cfg->obfuscator.value_regex);
+    ret = true;
+end:
+    free(key_regex);
+    free(value_regex);
+    return ret;
 }
 
 static jobject _create_result_checked(JNIEnv *env, DDWAF_RET_CODE code,
                                       const ddwaf_object *ddwaf_result)
 {
-    bool has_events = _has_events(ddwaf_result);
+    /* Since libddwaf 2.x a DDWAF_MATCH may be returned because of attributes or
+     * actions alone, with no event at all, so the return code cannot be used as
+     * a proxy for "there are events": the events array itself must be
+     * inspected. */
+    const ddwaf_object *events_obj =
+            ddwaf_object_find(ddwaf_result, LSTR("events"));
+    bool has_events = events_obj != NULL && ddwaf_object_is_array(events_obj) &&
+                      ddwaf_object_get_size(events_obj) > 0;
+
     const ddwaf_object *actions_obj =
-            ddwaf_object_find(ddwaf_result, "actions", 7);
+            ddwaf_object_find(ddwaf_result, LSTR("actions"));
     jobject actions_jmap;
     bool del_actions_jmap = false;
-    if (actions_obj == NULL || actions_obj->type != DDWAF_OBJ_MAP ||
-        ddwaf_object_size(actions_obj) == 0) {
+    if (actions_obj == NULL || !ddwaf_object_is_map(actions_obj) ||
+        ddwaf_object_get_size(actions_obj) == 0) {
         actions_jmap = _result_with_data_empty_map;
     } else {
         actions_jmap = convert_ddwaf_object_to_jobject(env, actions_obj);
@@ -2175,12 +2315,9 @@ static jobject _create_result_checked(JNIEnv *env, DDWAF_RET_CODE code,
         del_actions_jmap = true;
     }
 
-    // Get events from the ddwaf_object structure and use as data
-    const ddwaf_object *events_obj =
-            ddwaf_object_find(ddwaf_result, "events", 6);
+    // Use the events from the ddwaf_object structure as data
     jstring data_obj = NULL;
-    if (events_obj != NULL && events_obj->type == DDWAF_OBJ_ARRAY &&
-        ddwaf_object_size(events_obj) > 0) {
+    if (has_events) {
         struct json_segment *seg = output_convert_json(events_obj);
         if (!seg) {
             JNI(ThrowNew, jcls_iae, "failed converting events array to json");
@@ -2195,15 +2332,12 @@ static jobject _create_result_checked(JNIEnv *env, DDWAF_RET_CODE code,
         }
     }
 
-    // Get attributes (formerly derivatives) from the new ddwaf_object structure
+    // Get attributes (formerly derivatives) from the ddwaf_object structure
     const ddwaf_object *attributes_obj =
-            ddwaf_object_find(ddwaf_result, "attributes", 10);
+            ddwaf_object_find(ddwaf_result, LSTR("attributes"));
     jobject attributes = NULL;
-
-    consume_json_and_free(ddwaf_result);
-    consume_json_and_free(attributes_obj);
-    if (attributes_obj != NULL && attributes_obj->type == DDWAF_OBJ_MAP &&
-        ddwaf_object_size(attributes_obj) > 0) {
+    if (attributes_obj != NULL && ddwaf_object_is_map(attributes_obj) &&
+        ddwaf_object_get_size(attributes_obj) > 0) {
         attributes = output_convert_attributes_checked(env, attributes_obj);
         if (!attributes) {
             java_wrap_exc("%s", "Failed encoding inferred attributes");
@@ -2212,18 +2346,14 @@ static jobject _create_result_checked(JNIEnv *env, DDWAF_RET_CODE code,
     }
 
     // Get keep and duration from the ddwaf_object structure
-    const ddwaf_object *keep_obj = ddwaf_object_find(ddwaf_result, "keep", 4);
+    const ddwaf_object *keep_obj =
+            ddwaf_object_find(ddwaf_result, LSTR("keep"));
     jboolean keep = JNI_TRUE; // Default to true when NULL/missing
-    if (keep_obj != NULL && keep_obj->type == DDWAF_OBJ_BOOL) {
+    if (keep_obj != NULL && ddwaf_object_get_type(keep_obj) == DDWAF_OBJ_BOOL) {
         keep = (jboolean) ddwaf_object_get_bool(keep_obj);
     }
 
-    const ddwaf_object *duration_obj =
-            ddwaf_object_find(ddwaf_result, "duration", 8);
-    jlong duration = 0;
-    if (duration_obj != NULL && duration_obj->type == DDWAF_OBJ_UNSIGNED) {
-        duration = (jlong) ddwaf_object_get_unsigned(duration_obj);
-    }
+    jlong duration = (jlong) _get_duration(ddwaf_result);
 
     jobject result = java_meth_call(
             env, &result_with_data_init, NULL,
@@ -2242,28 +2372,13 @@ err:
     return NULL;
 }
 
-static inline bool _has_events(const ddwaf_object *res)
+/* The time the evaluation took, in microseconds; 0 when absent. */
+static uint64_t _get_duration(const ddwaf_object *res)
 {
-    const ddwaf_object *events_obj = ddwaf_object_find(res, "event", 5);
-    return events_obj == NULL || (events_obj->type == DDWAF_OBJ_BOOL &&
-                                  ddwaf_object_get_bool(events_obj));
-}
-
-static void consume_json_and_free(const ddwaf_object *obj)
-{
-    if (!obj)
-        return;
-    struct json_segment *seg = output_convert_json(obj);
-    if (!seg)
-        return;
-
-    size_t len = json_length(seg);
-    char *str = malloc(len + 1);
-    if (str) {
-        struct json_iterator it = {.seg = seg, .pos = 0};
-        size_t read = json_it_read(&it, str, len);
-        str[read] = '\0';
-        free(str);
+    const ddwaf_object *duration_obj = ddwaf_object_find(res, LSTR("duration"));
+    if (duration_obj != NULL &&
+        ddwaf_object_get_type(duration_obj) == DDWAF_OBJ_UNSIGNED) {
+        return ddwaf_object_get_unsigned(duration_obj);
     }
-    json_seg_free(seg);
+    return 0;
 }

--- a/src/main/c/waf_jni.c
+++ b/src/main/c/waf_jni.c
@@ -107,7 +107,7 @@ static uint64_t _get_duration(const ddwaf_object *res);
 /* Default per-run timeout in microseconds, overridable through the
  * DD_APPSEC_WAF_TIMEOUT system property. libddwaf used to export this as
  * DDWAF_RUN_TIMEOUT, but that macro was removed in 2.0. */
-#define DDWAF_RUN_TIMEOUT 5000
+#define LIBDDWAF_JAVA_RUN_TIMEOUT 5000
 
 jclass jcls_rte;
 jclass jcls_iae;
@@ -1442,7 +1442,11 @@ static void _dispose_of_cache_references(JNIEnv *env)
     _dispose_of_cached_methods(env);
 }
 
-/* clamps a container size to what libddwaf's uint16_t capacity can hold */
+/* clamps a container size to what libddwaf's uint16_t capacity can hold.
+ *
+ * This 65535-entry cap did not exist before the migration to libddwaf 2.x
+ * (ddwaf_object size/capacity became uint16); truncation here is a new, real
+ * behavior change worth surfacing at WARN rather than DEBUG/INFO. */
 static uint16_t _clamp_capacity(jsize len)
 {
     if (len < 0) {
@@ -1535,7 +1539,7 @@ static void _convert_checked(JNIEnv *env, ddwaf_object *out, jobject obj,
                 break;
             }
             if (inserted >= MAX_CONTAINER_SIZE) {
-                JAVA_LOG(DDWAF_LOG_INFO,
+                JAVA_LOG(DDWAF_LOG_WARN,
                          "Interrupting iterating array due to the maximum "
                          "container size of %d being reached",
                          MAX_CONTAINER_SIZE);
@@ -1563,7 +1567,8 @@ static void _convert_checked(JNIEnv *env, ddwaf_object *out, jobject obj,
         if (JNI(ExceptionCheck)) {
             goto error;
         }
-        ddwaf_object_set_map(out, too_deep ? 0 : _clamp_capacity(map_len), alloc);
+        ddwaf_object_set_map(out, too_deep ? 0 : _clamp_capacity(map_len),
+                             alloc);
         if (too_deep) {
             JAVA_LOG(DDWAF_LOG_DEBUG,
                      "Leaving map empty because max depth of %d "
@@ -1588,7 +1593,7 @@ static void _convert_checked(JNIEnv *env, ddwaf_object *out, jobject obj,
                 break;
             }
             if (inserted >= MAX_CONTAINER_SIZE) {
-                JAVA_LOG(DDWAF_LOG_INFO,
+                JAVA_LOG(DDWAF_LOG_WARN,
                          "Interrupting map iteration due to the maximum "
                          "container size of %d being reached",
                          MAX_CONTAINER_SIZE);
@@ -1668,7 +1673,7 @@ static void _convert_checked(JNIEnv *env, ddwaf_object *out, jobject obj,
                 break;
             }
             if (inserted >= MAX_CONTAINER_SIZE) {
-                JAVA_LOG(DDWAF_LOG_INFO,
+                JAVA_LOG(DDWAF_LOG_WARN,
                          "Interrupting iterable iteration due to the maximum "
                          "container size of %d being reached",
                          MAX_CONTAINER_SIZE);
@@ -2018,7 +2023,7 @@ static struct _limits _fetch_limits_checked(JNIEnv *env, jobject limits_obj)
 
     return l;
 error:
-    return (struct _limits) {0};
+    return (struct _limits){0};
 }
 
 static bool _get_time_checked(JNIEnv *env, struct timespec *time)
@@ -2043,7 +2048,7 @@ static int64_t _get_pw_run_timeout_checked(JNIEnv *env)
     jstring env_key = NULL;
     jstring val_jstr = NULL;
     char *val_cstr = NULL;
-    long long val = DDWAF_RUN_TIMEOUT;
+    long long val = LIBDDWAF_JAVA_RUN_TIMEOUT;
 
     if (!java_meth_init_checked(
                 env, &get_prop, "java/lang/System", "getProperty",
@@ -2272,6 +2277,13 @@ static bool _apply_obfuscator_config_checked(JNIEnv *env, ddwaf_builder builder,
     ddwaf_object_set_string(value_regex_slot, value_regex ? value_regex : "",
                             (uint32_t) value_regex_len, alloc);
 
+    /* NOTE: libddwaf's builder has a single global "obfuscator" config section
+     * shared across all registered configs. If a future config source (e.g.
+     * remote-config) also carries an "obfuscator" key, it will be rejected as
+     * "duplicate obfuscator configuration" (and, due to an upstream
+     * diagnostics bug, surfaced under the "scanners" section instead of
+     * "obfuscator"). This binding is currently the only registrant, so it is
+     * not reachable today. */
     bool added = ddwaf_builder_add_or_update_config(
             builder, LSTR(OBFUSCATOR_CONFIG_PATH), &config, NULL);
     ddwaf_object_destroy(&config, alloc);
@@ -2372,7 +2384,7 @@ err:
     return NULL;
 }
 
-/* The time the evaluation took, in microseconds; 0 when absent. */
+/* The time the evaluation took, in nanoseconds; 0 when absent. */
 static uint64_t _get_duration(const ddwaf_object *res)
 {
     const ddwaf_object *duration_obj = ddwaf_object_find(res, LSTR("duration"));

--- a/src/main/java/com/datadog/ddwaf/ByteBufferSerializer.java
+++ b/src/main/java/com/datadog/ddwaf/ByteBufferSerializer.java
@@ -485,6 +485,7 @@ public class ByteBufferSerializer {
       long tmp = (long) s.length() * MAX_BYTES_PER_CHAR_UTF8 + 1; // 0 terminated
       if (tmp > Integer.MAX_VALUE) {
         // overflow ahead
+        PWArgsBuffer.setInvalid(dest, off);
         return false;
       }
       int maxBytes = (int) tmp;
@@ -741,8 +742,24 @@ public class ByteBufferSerializer {
       buffer.putLong(off + 8, 0L);
     }
 
+    /**
+     * Writes a {@code DDWAF_OBJ_INVALID} (type byte 0x00, rest zeroed) into the object slot at
+     * {@code off}.
+     *
+     * <p>Used on every write failure path. All 6 current callers convert a write failure into a
+     * thrown exception before this buffer reaches JNI, but zero the slot anyway as defense in depth
+     * against a stale pointer reaching libddwaf if a future caller doesn't: arenas are pooled and
+     * recycled, so a half-written slot would otherwise still hold the bytes (including a possibly
+     * dangling {@code char*}) of a previous serialization run.
+     */
+    static void setInvalid(ByteBuffer buffer, int off) {
+      clearObject(buffer, off);
+      buffer.put(off + OFF_TYPE, (byte) PWInputType.PWI_INVALID.value);
+    }
+
     boolean writeNull(Arena arena, String parameterName) {
       if (!putParameterName(arena, parameterName)) { // string too large
+        setInvalid(this.buffer, valueOffset);
         return false;
       }
       clearObject(this.buffer, valueOffset);
@@ -752,6 +769,7 @@ public class ByteBufferSerializer {
 
     boolean writeBool(Arena arena, String parameterName, boolean value) {
       if (!putParameterName(arena, parameterName)) { // string too large
+        setInvalid(this.buffer, valueOffset);
         return false;
       }
       clearObject(this.buffer, valueOffset);
@@ -762,6 +780,7 @@ public class ByteBufferSerializer {
 
     boolean writeString(Arena arena, String parameterName, CharSequence value) {
       if (!putParameterName(arena, parameterName)) { // string too large
+        setInvalid(this.buffer, valueOffset);
         return false;
       }
       return arena.writeStringObject(this.buffer, valueOffset, value);
@@ -769,6 +788,7 @@ public class ByteBufferSerializer {
 
     boolean writeLong(Arena arena, String parameterName, long value) {
       if (!putParameterName(arena, parameterName)) { // string too large
+        setInvalid(this.buffer, valueOffset);
         return false;
       }
       clearObject(this.buffer, valueOffset);
@@ -779,6 +799,7 @@ public class ByteBufferSerializer {
 
     boolean writeDouble(Arena arena, String parameterName, double value) {
       if (!putParameterName(arena, parameterName)) { // string too large
+        setInvalid(this.buffer, valueOffset);
         return false;
       }
       clearObject(this.buffer, valueOffset);
@@ -797,10 +818,15 @@ public class ByteBufferSerializer {
 
     private PWArgsArrayBuffer writeArrayOrMap(
         Arena arena, String parameterName, int numElements, PWInputType type) {
+      // Defence in depth: unreachable today, since every caller goes through
+      // clampContainerSize(), which already caps sizes to MAX_CONTAINER_SIZE. Kept so that a
+      // future change to the callers (or to Waf.Limits.maxElements) cannot silently reintroduce
+      // a uint16 wraparound in the size/capacity fields.
       if (numElements < 0 || numElements > MAX_CONTAINER_SIZE) {
         throw new IllegalArgumentException("Invalid container size: " + numElements);
       }
       if (!putParameterName(arena, parameterName)) { // string too large
+        setInvalid(this.buffer, valueOffset);
         return null;
       }
       clearObject(this.buffer, valueOffset);
@@ -814,11 +840,13 @@ public class ByteBufferSerializer {
       PWArgsArrayBuffer pwArgsArrayBuffer = arena.allocatePWArgsBuffer(numElements, stride, false);
       if (pwArgsArrayBuffer == null) {
         // should not happen
+        setInvalid(this.buffer, valueOffset);
         return null;
       }
       long address = pwArgsArrayBuffer.getAddress();
       if (address == NULLPTR) {
         // should not happen
+        setInvalid(this.buffer, valueOffset);
         return null;
       }
       this.buffer.putShort(valueOffset + OFF_CONTAINER_SIZE, (short) numElements);

--- a/src/main/java/com/datadog/ddwaf/ByteBufferSerializer.java
+++ b/src/main/java/com/datadog/ddwaf/ByteBufferSerializer.java
@@ -379,7 +379,7 @@ public class ByteBufferSerializer {
   private static int clampContainerSize(int size, int[] remainingElements, WafMetrics metrics) {
     int capped = Math.min(size, remainingElements[0]);
     if (capped > MAX_CONTAINER_SIZE) {
-      LOGGER.debug(
+      LOGGER.warn(
           "Truncating container from size {} to size {} (libddwaf limit)",
           capped,
           MAX_CONTAINER_SIZE);

--- a/src/main/java/com/datadog/ddwaf/ByteBufferSerializer.java
+++ b/src/main/java/com/datadog/ddwaf/ByteBufferSerializer.java
@@ -21,6 +21,7 @@ import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.Deque;
@@ -31,9 +32,70 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Serializes Java objects into the raw binary representation of {@code ddwaf_object} (libddwaf 2.x)
+ * inside direct {@link ByteBuffer}s, so that libddwaf can consume them without any copy.
+ *
+ * <p>The binary layout replicated here is the one declared in {@code ddwaf.h}:
+ *
+ * <pre>
+ *   union _ddwaf_object {                     // 16 bytes, 8-byte aligned
+ *       uint8_t type;                         // +0
+ *       union {
+ *           struct { uint8_t type; bool val; }                          b8;   // val   +1
+ *           struct { uint8_t type; int64_t val; }                       i64;  // val   +8
+ *           struct { uint8_t type; uint64_t val; }                      u64;  // val   +8
+ *           struct { uint8_t type; double val; }                        f64;  // val   +8
+ *           struct { uint8_t type; uint32_t size; char *ptr; }          str;  // size  +4, ptr +8
+ *           struct { uint8_t type; uint8_t size; char data[14]; }       sstr; // size  +1, data +2
+ *           struct { uint8_t type; uint16_t size, capacity;
+ *                    ddwaf_object *ptr; }                               array;// size +2, cap +4,
+ *                                                                             // ptr  +8
+ *           struct { uint8_t type; uint16_t size, capacity;
+ *                    ddwaf_object_kv *ptr; }                            map;  // idem
+ *       } via;
+ *   };
+ *
+ *   struct _ddwaf_object_kv { ddwaf_object key; ddwaf_object val; };  // 32 bytes, key +0, val +16
+ * </pre>
+ *
+ * <p>Array children are plain 16-byte {@code ddwaf_object}s; map entries are 32-byte {@code
+ * ddwaf_object_kv}s. Both are allocated out of the same arena, which hands out 16-byte slots.
+ *
+ * <p>Since these constants are hand-rolled, {@link #checkNativeLayout()} cross-checks every one of
+ * them against the real C struct through {@link #getNativeObjectLayout()}; it is called from {@link
+ * Waf#initialize(boolean)} right after the native library is loaded, so a libddwaf layout change
+ * can never silently corrupt memory.
+ */
 public class ByteBufferSerializer {
   private static final long NULLPTR = 0;
-  private static final int SIZEOF_PWARGS = 40;
+
+  /** {@code sizeof(ddwaf_object)}. Also the arena allocation unit. */
+  private static final int SIZEOF_PWARGS = 16;
+
+  /** {@code sizeof(ddwaf_object_kv)}: a key object followed by a value object. */
+  private static final int SIZEOF_PWARGS_KV = 32;
+
+  /** {@code offsetof(ddwaf_object_kv, val)}. */
+  private static final int OFF_KV_VALUE = 16;
+
+  private static final int OFF_TYPE = 0;
+  private static final int OFF_BOOL_VAL = 1;
+  private static final int OFF_NUM_VAL = 8;
+  private static final int OFF_STR_SIZE = 4;
+  private static final int OFF_STR_PTR = 8;
+  private static final int OFF_SSTR_SIZE = 1;
+  private static final int OFF_SSTR_DATA = 2;
+  private static final int OFF_CONTAINER_SIZE = 2;
+  private static final int OFF_CONTAINER_CAPACITY = 4;
+  private static final int OFF_CONTAINER_PTR = 8;
+
+  /** {@code DDWAF_OBJ_SSTR_SIZE}: strings up to this length are stored inline in the object. */
+  private static final int MAX_SMALL_STRING_SIZE = 14;
+
+  /** Container {@code size}/{@code capacity} are {@code uint16_t} in libddwaf 2.x. */
+  private static final int MAX_CONTAINER_SIZE = 65535;
+
   private static final int PWARGS_MIN_SEGMENTS_SIZE = 512;
   private static final int STRINGS_MIN_SEGMENTS_SIZE = 81920;
 
@@ -63,6 +125,58 @@ public class ByteBufferSerializer {
 
   public static ArenaLease getBlankLease() {
     return ArenaPool.INSTANCE.getLease();
+  }
+
+  /**
+   * Returns the layout of {@code ddwaf_object}/{@code ddwaf_object_kv} as seen by the C compiler.
+   * See {@code Java_com_datadog_ddwaf_ByteBufferSerializer_getNativeObjectLayout} in {@code
+   * byte_buffer.c} for the meaning of each position.
+   */
+  private static native int[] getNativeObjectLayout();
+
+  /**
+   * Verifies the hardcoded layout constants of this class against the actual C structs.
+   *
+   * @throws IllegalStateException if libddwaf's object layout is not the one assumed here
+   */
+  static void checkNativeLayout() {
+    int[] expected =
+        new int[] {
+          SIZEOF_PWARGS,
+          SIZEOF_PWARGS_KV,
+          0, // offsetof(ddwaf_object_kv, key)
+          OFF_KV_VALUE,
+          OFF_TYPE,
+          OFF_BOOL_VAL,
+          OFF_NUM_VAL,
+          OFF_STR_SIZE,
+          OFF_STR_PTR,
+          OFF_SSTR_SIZE,
+          OFF_SSTR_DATA,
+          MAX_SMALL_STRING_SIZE,
+          OFF_CONTAINER_SIZE,
+          OFF_CONTAINER_CAPACITY,
+          OFF_CONTAINER_PTR,
+          PWInputType.PWI_INVALID.value,
+          PWInputType.PWI_NULL.value,
+          PWInputType.PWI_BOOL.value,
+          PWInputType.PWI_SIGNED.value,
+          PWInputType.PWI_UNSIGNED.value,
+          PWInputType.PWI_FLOAT.value,
+          PWInputType.PWI_STRING.value,
+          PWInputType.PWI_LITERAL_STRING.value,
+          PWInputType.PWI_SMALL_STRING.value,
+          PWInputType.PWI_ARRAY.value,
+          PWInputType.PWI_MAP.value,
+        };
+    int[] actual = getNativeObjectLayout();
+    if (!Arrays.equals(expected, actual)) {
+      throw new IllegalStateException(
+          "libddwaf ddwaf_object layout mismatch: ByteBufferSerializer assumes "
+              + Arrays.toString(expected)
+              + " but the native library reports "
+              + Arrays.toString(actual));
+    }
   }
 
   private static ByteBuffer serializeMore(
@@ -164,7 +278,7 @@ public class ByteBufferSerializer {
         throw new RuntimeException("Could not write number");
       }
     } else if (value instanceof Collection) {
-      int size = Math.min(((Collection<?>) value).size(), remainingElements[0]);
+      int size = clampContainerSize(((Collection<?>) value).size(), remainingElements, metrics);
 
       // TODO - ADD METRIC FOR UNTRUNCATED SIZE
       Iterator<?> iterator = ((Collection<?>) value).iterator();
@@ -179,7 +293,7 @@ public class ByteBufferSerializer {
           iterator,
           size);
     } else if (value.getClass().isArray()) {
-      int size = Math.min(Array.getLength(value), remainingElements[0]);
+      int size = clampContainerSize(Array.getLength(value), remainingElements, metrics);
 
       // TODO - ADD METRIC FOR UNTRUNCATED SIZE
       Iterator<?> iterator = new GenericArrayIterator(value);
@@ -197,11 +311,11 @@ public class ByteBufferSerializer {
       // we need to iterate twice
       Iterator<?> iterator = ((Iterable<?>) value).iterator();
       int size = 0;
-      int maxSize = remainingElements[0];
-      while (iterator.hasNext() && size < maxSize) {
+      while (iterator.hasNext() && size < remainingElements[0]) {
         iterator.next();
         size++;
       }
+      size = clampContainerSize(size, remainingElements, metrics);
 
       // TODO - ADD METRIC FOR UNTRUNCATED SIZE
       iterator = ((Iterable<?>) value).iterator();
@@ -216,7 +330,7 @@ public class ByteBufferSerializer {
           iterator,
           size);
     } else if (value instanceof Map) {
-      int size = Math.min(((Map<?, ?>) value).size(), remainingElements[0]);
+      int size = clampContainerSize(((Map<?, ?>) value).size(), remainingElements, metrics);
 
       // TODO - ADD METRIC FOR UNTRUNCATED SIZE
       PWArgsArrayBuffer pwArgsArrayBuffer = pwargsSlot.writeMap(arena, parameterName, size);
@@ -256,6 +370,25 @@ public class ByteBufferSerializer {
         throw new RuntimeException("Error writing null for unknown type");
       }
     }
+  }
+
+  /**
+   * Caps the number of children of a container to what the remaining element budget allows and to
+   * what libddwaf's {@code uint16_t} size field can represent.
+   */
+  private static int clampContainerSize(int size, int[] remainingElements, WafMetrics metrics) {
+    int capped = Math.min(size, remainingElements[0]);
+    if (capped > MAX_CONTAINER_SIZE) {
+      LOGGER.debug(
+          "Truncating container from size {} to size {} (libddwaf limit)",
+          capped,
+          MAX_CONTAINER_SIZE);
+      capped = MAX_CONTAINER_SIZE;
+      if (metrics != null) {
+        metrics.incrementTruncatedListMapTooLargeCount();
+      }
+    }
+    return capped;
   }
 
   private static void serializeIterable(
@@ -302,7 +435,6 @@ public class ByteBufferSerializer {
     List<StringsSegment> stringsSegments = new ArrayList<>();
     int curStringsSegment;
     CharBuffer currentWrapper = null;
-    WrittenString cachedWS = null;
 
     public final CharsetEncoder getCharsetEncoder() {
       CharsetEncoder charsetEncoder = utf8Encoder;
@@ -336,32 +468,13 @@ public class ByteBufferSerializer {
       return pwargsSegments.get(idxOfFirstUsedPWArgsSegment).buffer;
     }
 
-    static class WrittenString {
-      private final Arena arena;
-      private long ptr;
-      private int utf8len;
-
-      WrittenString(Arena arena) {
-        this.arena = arena;
-      }
-
-      public void release() {
-        arena.cachedWS = this;
-      }
-
-      public WrittenString update(long ptr, int utf8len) {
-        this.ptr = ptr;
-        this.utf8len = utf8len;
-        return this;
-      }
-    }
-
     /**
-     * @param s the string to serialize
-     * @return the native pointer to the string and its size in bytes, or null if the string is too
-     *     large
+     * Writes a string object (either a small string, stored inline, or a regular string pointing
+     * into the strings arena) into {@code dest} at offset {@code off}.
+     *
+     * @return false if the string is too large to be serialized
      */
-    WrittenString writeStringUnlimited(CharSequence s) {
+    boolean writeStringObject(ByteBuffer dest, int off, CharSequence s) {
       CharBuffer cb;
       if (s instanceof CharBuffer) {
         cb = ((CharBuffer) s).duplicate();
@@ -372,38 +485,49 @@ public class ByteBufferSerializer {
       long tmp = (long) s.length() * MAX_BYTES_PER_CHAR_UTF8 + 1; // 0 terminated
       if (tmp > Integer.MAX_VALUE) {
         // overflow ahead
-        return null;
+        return false;
       }
       int maxBytes = (int) tmp;
 
-      StringsSegment segment;
-      segment = stringsSegments.get(curStringsSegment);
-      WrittenString str = cachedWS;
-      if (str == null) {
-        cachedWS = str = new WrittenString(this);
-      }
-      while ((str = segment.writeNulTerminated(str, getCharsetEncoder(), cb, maxBytes)) == null) {
+      StringsSegment segment = stringsSegments.get(curStringsSegment);
+      int utf8len;
+      while ((utf8len = segment.write(getCharsetEncoder(), cb, maxBytes)) < 0) {
         segment = changeStringsSegment(Math.max(STRINGS_MIN_SEGMENTS_SIZE, maxBytes));
-        str = cachedWS;
       }
-      cachedWS = null;
-      return str;
+
+      // write() leaves the buffer positioned right after the encoded bytes plus the
+      // NUL terminator it appends, so the start of the string it just wrote is always
+      // (current position - encoded length - 1 NUL byte) bytes back.
+      int start = segment.buffer.position() - utf8len - 1;
+      PWArgsBuffer.clearObject(dest, off);
+      if (utf8len <= MAX_SMALL_STRING_SIZE) {
+        // small strings live inside the object itself; give the arena space back
+        dest.put(off + OFF_TYPE, (byte) PWInputType.PWI_SMALL_STRING.value);
+        dest.put(off + OFF_SSTR_SIZE, (byte) utf8len);
+        for (int i = 0; i < utf8len; i++) {
+          dest.put(off + OFF_SSTR_DATA + i, segment.buffer.get(start + i));
+        }
+        segment.rollbackTo(start);
+      } else {
+        dest.put(off + OFF_TYPE, (byte) PWInputType.PWI_STRING.value);
+        dest.putInt(off + OFF_STR_SIZE, utf8len);
+        dest.putLong(off + OFF_STR_PTR, segment.base + start);
+      }
+      return true;
     }
 
     PWArgsArrayBuffer allocateGetAddressCompatiblePWArgsBuffer(int num) {
-      return allocatePWArgsBuffer(num, true);
+      return allocatePWArgsBuffer(num, SIZEOF_PWARGS, true);
     }
 
-    PWArgsArrayBuffer allocatePWArgsBuffer(int num) {
-      return allocatePWArgsBuffer(num, false);
-    }
-
-    private PWArgsArrayBuffer allocatePWArgsBuffer(int num, boolean getAddressCompatible) {
+    private PWArgsArrayBuffer allocatePWArgsBuffer(
+        int num, int stride, boolean getAddressCompatible) {
+      int slots = num * (stride / SIZEOF_PWARGS);
       PWArgsSegment segment;
       segment = pwargsSegments.get(curPWArgsSegment);
       PWArgsArrayBuffer array;
-      while ((array = segment.allocate(num, getAddressCompatible)) == null) {
-        segment = changePWArgsSegment(Math.max(PWARGS_MIN_SEGMENTS_SIZE, num));
+      while ((array = segment.allocate(slots, num, stride, getAddressCompatible)) == null) {
+        segment = changePWArgsSegment(Math.max(PWARGS_MIN_SEGMENTS_SIZE, slots));
       }
       if (idxOfFirstUsedPWArgsSegment == -1) {
         idxOfFirstUsedPWArgsSegment = curPWArgsSegment;
@@ -483,6 +607,10 @@ public class ByteBufferSerializer {
     }
   }
 
+  /**
+   * A chunk of direct memory handing out 16-byte slots ({@code sizeof(ddwaf_object)}). Map entries
+   * take two consecutive slots each ({@code sizeof(ddwaf_object_kv)}).
+   */
   static class PWArgsSegment {
     ByteBuffer buffer;
     List<PWArgsArrayBuffer> pwargsArrays = new ArrayList<>();
@@ -494,26 +622,25 @@ public class ByteBufferSerializer {
       this.buffer.order(ByteOrder.nativeOrder());
     }
 
-    PWArgsArrayBuffer allocate(int num, boolean getAddressCompatible) {
-      if (left() < num) {
+    PWArgsArrayBuffer allocate(int slots, int num, int stride, boolean getAddressCompatible) {
+      if (left() < slots) {
         return null;
       }
       int position = this.buffer.position();
       PWArgsArrayBuffer arrayBuffer;
       if (getAddressCompatible) {
         ByteBuffer slice = this.buffer.slice().order(ByteOrder.nativeOrder());
-        arrayBuffer = new PWArgsArrayBuffer(slice, 0, num);
+        arrayBuffer = new PWArgsArrayBuffer(slice, 0, num, stride);
       } else if (idxOfNextUnusedPWArgsArrayBuffer >= pwargsArrays.size()) {
-        ByteBuffer duplicate = this.buffer.duplicate().order(ByteOrder.nativeOrder());
-        arrayBuffer = new PWArgsArrayBuffer(duplicate, position, num);
+        arrayBuffer = new PWArgsArrayBuffer(this.buffer, position, num, stride);
         pwargsArrays.add(arrayBuffer);
         idxOfNextUnusedPWArgsArrayBuffer++;
       } else {
         arrayBuffer = pwargsArrays.get(idxOfNextUnusedPWArgsArrayBuffer);
-        arrayBuffer.reset(position, num);
+        arrayBuffer.reset(position, num, stride);
         idxOfNextUnusedPWArgsArrayBuffer++;
       }
-      this.buffer.position(position + num * SIZEOF_PWARGS);
+      this.buffer.position(position + slots * SIZEOF_PWARGS);
       return arrayBuffer;
     }
 
@@ -527,23 +654,27 @@ public class ByteBufferSerializer {
     }
   }
 
+  /**
+   * The children of a container: {@code num} entries of {@code stride} bytes each, either 16 bytes
+   * ({@code ddwaf_object}, for arrays) or 32 bytes ({@code ddwaf_object_kv}, for maps).
+   */
   static class PWArgsArrayBuffer {
     private final ByteBuffer buffer;
     private int start;
     private int num;
+    private int stride;
     private final List<PWArgsBuffer> pwArgsBuffers;
 
     static final PWArgsArrayBuffer EMPTY_BUFFER = new PWArgsArrayBuffer();
 
-    PWArgsArrayBuffer(ByteBuffer buffer, int start, int num) {
+    PWArgsArrayBuffer(ByteBuffer buffer, int start, int num, int stride) {
       if (num == 0 || buffer == null) {
         throw new IllegalArgumentException();
       }
       this.buffer = buffer;
       this.start = start;
       this.num = num;
-      buffer.limit(start + num * SIZEOF_PWARGS);
-      buffer.position(start);
+      this.stride = stride;
       this.pwArgsBuffers = new ArrayList<>(num);
     }
 
@@ -551,14 +682,14 @@ public class ByteBufferSerializer {
       this.buffer = null;
       this.start = 0;
       this.num = 0;
+      this.stride = SIZEOF_PWARGS;
       this.pwArgsBuffers = null;
     }
 
-    void reset(int start, int num) {
+    void reset(int start, int num, int stride) {
       this.start = start;
       this.num = num;
-      this.buffer.limit(start + num * SIZEOF_PWARGS);
-      this.buffer.position(start);
+      this.stride = stride;
     }
 
     PWArgsBuffer get(int i) {
@@ -567,11 +698,10 @@ public class ByteBufferSerializer {
       }
       assert this.buffer != null;
       while (i >= pwArgsBuffers.size()) {
-        ByteBuffer duplicate = this.buffer.duplicate().order(ByteOrder.nativeOrder());
-        pwArgsBuffers.add(new PWArgsBuffer(duplicate, start + i * SIZEOF_PWARGS));
+        pwArgsBuffers.add(new PWArgsBuffer(this.buffer));
       }
       PWArgsBuffer pwArgsBuffer = pwArgsBuffers.get(i);
-      pwArgsBuffer.reset(start + i * SIZEOF_PWARGS);
+      pwArgsBuffer.reset(start + i * stride, stride == SIZEOF_PWARGS_KV);
       return pwArgsBuffer;
     }
 
@@ -584,61 +714,49 @@ public class ByteBufferSerializer {
     }
   }
 
-  /*
-   * This is the structure until we get improvements:
-   *
-   * https://github.com/sqreen/PowerWAF/issues/201
-   *
-   *  struct _PWArgs
-   *  {
-   *      const char* parameterName;
-   *      uint64_t parameterNameLength;
-   *      union
-   *      {
-   *          const char* stringValue;
-   *          uint64_t uintValue;
-   *          int64_t intValue;
-   *          const PWArgs* array;
-   *          bool boolean;
-   *          double f64;
-   *      };
-   *      uint64_t nbEntries;
-   *      PW_INPUT_TYPE type;
-   *  };
+  /**
+   * A single slot to write a {@code ddwaf_object} into. When the slot belongs to a map it actually
+   * spans a whole {@code ddwaf_object_kv}: the key object is written at {@code start} and the value
+   * object at {@code start + 16}.
    */
   static class PWArgsBuffer {
     private final ByteBuffer buffer;
+    private int keyOffset;
+    private int valueOffset;
 
-    PWArgsBuffer(ByteBuffer buffer, int start) {
+    /** Creates an unpositioned slot; {@link #reset} must be called before writing to it. */
+    PWArgsBuffer(ByteBuffer buffer) {
       this.buffer = buffer;
-      this.buffer.limit(start + SIZEOF_PWARGS);
-      this.buffer.position(start);
+      this.keyOffset = -1;
+      this.valueOffset = -1;
     }
 
-    void reset(int start) {
-      this.buffer.limit(start + SIZEOF_PWARGS);
-      this.buffer.position(start);
+    void reset(int start, boolean isMapEntry) {
+      this.keyOffset = isMapEntry ? start : -1;
+      this.valueOffset = isMapEntry ? start + OFF_KV_VALUE : start;
+    }
+
+    static void clearObject(ByteBuffer buffer, int off) {
+      buffer.putLong(off, 0L);
+      buffer.putLong(off + 8, 0L);
     }
 
     boolean writeNull(Arena arena, String parameterName) {
       if (!putParameterName(arena, parameterName)) { // string too large
         return false;
       }
-      this.buffer.putLong(0).putLong(0).putInt(PWInputType.PWI_NULL.value);
+      clearObject(this.buffer, valueOffset);
+      this.buffer.put(valueOffset + OFF_TYPE, (byte) PWInputType.PWI_NULL.value);
       return true;
     }
-
-    private static final byte[] BOOL_TRUE_REPR = new byte[] {1, 0, 0, 0, 0, 0, 0, 0};
-    private static final byte[] BOOL_FALSE_REPR = new byte[] {0, 0, 0, 0, 0, 0, 0, 0};
 
     boolean writeBool(Arena arena, String parameterName, boolean value) {
       if (!putParameterName(arena, parameterName)) { // string too large
         return false;
       }
-      this.buffer
-          .put(value ? BOOL_TRUE_REPR : BOOL_FALSE_REPR)
-          .putLong(0)
-          .putInt(PWInputType.PWI_BOOL.value);
+      clearObject(this.buffer, valueOffset);
+      this.buffer.put(valueOffset + OFF_TYPE, (byte) PWInputType.PWI_BOOL.value);
+      this.buffer.put(valueOffset + OFF_BOOL_VAL, (byte) (value ? 1 : 0));
       return true;
     }
 
@@ -646,23 +764,16 @@ public class ByteBufferSerializer {
       if (!putParameterName(arena, parameterName)) { // string too large
         return false;
       }
-      Arena.WrittenString writtenString = arena.writeStringUnlimited(value);
-      if (writtenString == null) { // string too large
-        return false;
-      }
-      this.buffer
-          .putLong(writtenString.ptr)
-          .putLong(writtenString.utf8len)
-          .putInt(PWInputType.PWI_STRING.value);
-      writtenString.release();
-      return true;
+      return arena.writeStringObject(this.buffer, valueOffset, value);
     }
 
     boolean writeLong(Arena arena, String parameterName, long value) {
       if (!putParameterName(arena, parameterName)) { // string too large
         return false;
       }
-      this.buffer.putLong(value).putLong(0).putInt(PWInputType.PWI_SIGNED_NUMBER.value);
+      clearObject(this.buffer, valueOffset);
+      this.buffer.put(valueOffset + OFF_TYPE, (byte) PWInputType.PWI_SIGNED.value);
+      this.buffer.putLong(valueOffset + OFF_NUM_VAL, value);
       return true;
     }
 
@@ -670,7 +781,9 @@ public class ByteBufferSerializer {
       if (!putParameterName(arena, parameterName)) { // string too large
         return false;
       }
-      this.buffer.putDouble(value).putLong(0).putInt(PWInputType.PWI_FLOAT.value);
+      clearObject(this.buffer, valueOffset);
+      this.buffer.put(valueOffset + OFF_TYPE, (byte) PWInputType.PWI_FLOAT.value);
+      this.buffer.putDouble(valueOffset + OFF_NUM_VAL, value);
       return true;
     }
 
@@ -684,15 +797,21 @@ public class ByteBufferSerializer {
 
     private PWArgsArrayBuffer writeArrayOrMap(
         Arena arena, String parameterName, int numElements, PWInputType type) {
+      if (numElements < 0 || numElements > MAX_CONTAINER_SIZE) {
+        throw new IllegalArgumentException("Invalid container size: " + numElements);
+      }
       if (!putParameterName(arena, parameterName)) { // string too large
         return null;
       }
+      clearObject(this.buffer, valueOffset);
+      this.buffer.put(valueOffset + OFF_TYPE, (byte) type.value);
       if (numElements == 0) {
-        this.buffer.putLong(0L).putLong(0L).putInt(type.value);
+        // size = capacity = 0, ptr = NULL
         return PWArgsArrayBuffer.EMPTY_BUFFER;
       }
 
-      PWArgsArrayBuffer pwArgsArrayBuffer = arena.allocatePWArgsBuffer(numElements);
+      int stride = type == PWInputType.PWI_MAP ? SIZEOF_PWARGS_KV : SIZEOF_PWARGS;
+      PWArgsArrayBuffer pwArgsArrayBuffer = arena.allocatePWArgsBuffer(numElements, stride, false);
       if (pwArgsArrayBuffer == null) {
         // should not happen
         return null;
@@ -702,36 +821,37 @@ public class ByteBufferSerializer {
         // should not happen
         return null;
       }
-      this.buffer.putLong(address).putLong(numElements).putInt(type.value);
+      this.buffer.putShort(valueOffset + OFF_CONTAINER_SIZE, (short) numElements);
+      this.buffer.putShort(valueOffset + OFF_CONTAINER_CAPACITY, (short) numElements);
+      this.buffer.putLong(valueOffset + OFF_CONTAINER_PTR, address);
       return pwArgsArrayBuffer;
     }
 
     private boolean putParameterName(Arena arena, String parameterName) {
-      if (parameterName == null) {
-        this.buffer.putLong(0L).putLong(0L);
-      } else {
-        Arena.WrittenString writtenString = arena.writeStringUnlimited(parameterName);
-        if (writtenString == null) { // string too large
-          return false;
-        }
-        this.buffer.putLong(writtenString.ptr).putLong(writtenString.utf8len);
-        writtenString.release();
+      if (keyOffset < 0) {
+        // not a map entry: there is no key slot to write to
+        return true;
       }
-
-      return true;
+      // callers are expected never to pass a null key for a map entry, but keep the invariant
+      // local: an absent key is written as the empty string
+      return arena.writeStringObject(
+          this.buffer, keyOffset, parameterName == null ? "" : parameterName);
     }
   }
 
+  /** Mirrors {@code DDWAF_OBJ_TYPE}. These are bitmask values, not sequential ordinals. */
   enum PWInputType {
-    PWI_INVALID(0),
-    PWI_SIGNED_NUMBER(1),
-    PWI_UNSIGNED_NUMBER(2),
-    PWI_STRING(4),
-    PWI_ARRAY(8),
-    PWI_MAP(16),
-    PWI_BOOL(32),
-    PWI_FLOAT(64),
-    PWI_NULL(128);
+    PWI_INVALID(0x00),
+    PWI_NULL(0x01),
+    PWI_BOOL(0x02),
+    PWI_SIGNED(0x04),
+    PWI_UNSIGNED(0x06),
+    PWI_FLOAT(0x08),
+    PWI_STRING(0x10),
+    PWI_LITERAL_STRING(0x12),
+    PWI_SMALL_STRING(0x14),
+    PWI_ARRAY(0x20),
+    PWI_MAP(0x40);
 
     int value;
 
@@ -759,13 +879,16 @@ public class ByteBufferSerializer {
       buffer.clear();
     }
 
-    Arena.WrittenString writeNulTerminated(
-        Arena.WrittenString writtenString, CharsetEncoder encoder, CharBuffer in, int maxBytes) {
+    /**
+     * Encodes {@code in} as UTF-8 at the current position, followed by a NUL byte.
+     *
+     * @return the encoded length in bytes (excluding the NUL), or -1 if it does not fit
+     */
+    int write(CharsetEncoder encoder, CharBuffer in, int maxBytes) {
       if (left() < maxBytes) {
-        return null;
+        return -1;
       }
       int position = this.buffer.position();
-      long ptr = base + position;
       if (maxBytes > 1 && in.hasRemaining()) {
         try {
           CoderResult cr = encoder.encode(in, this.buffer, true);
@@ -781,7 +904,12 @@ public class ByteBufferSerializer {
       int bytesLen = this.buffer.position() - position;
       this.buffer.put(NUL_TERMINATOR);
 
-      return writtenString.update(ptr, bytesLen);
+      return bytesLen;
+    }
+
+    /** Gives back the space taken by the last string written (it was inlined in the object). */
+    void rollbackTo(int position) {
+      this.buffer.position(position);
     }
 
     private int left() {

--- a/src/main/java/com/datadog/ddwaf/Waf.java
+++ b/src/main/java/com/datadog/ddwaf/Waf.java
@@ -20,12 +20,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class Waf {
-  public static final String LIB_VERSION = "1.30.0";
+  public static final String LIB_VERSION = "2.0.1";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Waf.class);
   static final boolean EXIT_ON_LEAK;
 
-  private static boolean triedInitializing;
+  private static boolean triedLoadingLib;
+  private static boolean loadedLib;
   private static boolean initialized;
 
   static {
@@ -35,28 +36,47 @@ public final class Waf {
 
   private Waf() {}
 
+  /**
+   * Loads the native library and verifies it against the layout assumptions of {@link
+   * ByteBufferSerializer}.
+   *
+   * <p>A failure to load the native library is not retried: a subsequent call throws {@link
+   * UnclassifiedWafException}. A failure of the layout check, on the other hand, leaves the
+   * (already loaded) library alone, so a subsequent call retries the check and fails the same way
+   * again.
+   *
+   * @throws IllegalStateException if the layout of libddwaf's {@code ddwaf_object} is not the one
+   *     {@link ByteBufferSerializer} assumes
+   */
   public static synchronized void initialize(boolean simple)
       throws AbstractWafException, UnsupportedVMException {
     if (initialized) {
       return;
     }
 
-    if (triedInitializing) {
-      throw new UnclassifiedWafException(
-          "Previously loading attempt of sqreen_jni failed; not retrying");
+    if (!loadedLib) {
+      if (triedLoadingLib) {
+        throw new UnclassifiedWafException(
+            "Previously loading attempt of sqreen_jni failed; not retrying");
+      }
+
+      triedLoadingLib = true;
+      try {
+        if (simple) {
+          System.loadLibrary("sqreen_jni");
+        } else {
+          NativeLibLoader.load();
+        }
+      } catch (IOException e) {
+        LOGGER.error("Failure loading native library", e);
+        throw new RuntimeException("Error loading native lib", e);
+      }
+      loadedLib = true;
     }
 
-    triedInitializing = true;
-    try {
-      if (simple) {
-        System.loadLibrary("sqreen_jni");
-      } else {
-        NativeLibLoader.load();
-      }
-    } catch (IOException e) {
-      LOGGER.error("Failure loading native library", e);
-      throw new RuntimeException("Error loading native lib", e);
-    }
+    // ByteBufferSerializer hand-rolls libddwaf's ddwaf_object binary layout; make sure the
+    // assumption still holds for the library we just loaded rather than corrupting memory later
+    ByteBufferSerializer.checkNativeLayout();
     initialized = true;
   }
 

--- a/src/main/java/com/datadog/ddwaf/Waf.java
+++ b/src/main/java/com/datadog/ddwaf/Waf.java
@@ -83,6 +83,14 @@ public final class Waf {
   /** (FOR TESTING PURPOSES ONLY) Converts a ByteBuffer to a String. */
   static native String pwArgsBufferToString(ByteBuffer firstPWArgsBuffer);
 
+  /**
+   * (FOR TESTING PURPOSES ONLY) Builds a fixed object tree through libddwaf's official {@code
+   * ddwaf_object_set_*} API and renders it with the same printer as {@link
+   * #pwArgsBufferToString(ByteBuffer)}, so that the tree {@link ByteBufferSerializer} produces for
+   * the equivalent Java value can be compared against it.
+   */
+  static native String referenceObjectTreeToString();
+
   public static native String getVersion();
 
   /**

--- a/src/main/java/com/datadog/ddwaf/WafContext.java
+++ b/src/main/java/com/datadog/ddwaf/WafContext.java
@@ -9,6 +9,7 @@
 package com.datadog.ddwaf;
 
 import com.datadog.ddwaf.exception.AbstractWafException;
+import com.datadog.ddwaf.exception.InvalidArgumentWafException;
 import com.datadog.ddwaf.exception.TimeoutWafException;
 import com.datadog.ddwaf.exception.UnclassifiedWafException;
 import java.io.Closeable;
@@ -59,6 +60,15 @@ public class WafContext implements Closeable {
 
   private static native long initWafContext(WafHandle handle);
 
+  /**
+   * Evaluates one batch of data.
+   *
+   * <p>Exactly one of the two buffers must be non-null: persistent data is evaluated against the
+   * context itself ({@code ddwaf_context_eval}), while ephemeral data is evaluated against a
+   * throw-away subcontext ({@code ddwaf_subcontext_init}/{@code eval}/{@code destroy}). libddwaf
+   * 2.x has no combined mode, and each evaluation yields its own result, so passing both (or
+   * neither) fails with {@link com.datadog.ddwaf.exception.InvalidArgumentWafException}.
+   */
   private native Waf.ResultWithData runWafContext(
       ByteBuffer persistentBuffer,
       ByteBuffer ephemeralBuffer,
@@ -75,7 +85,8 @@ public class WafContext implements Closeable {
   private native void clearWafContext();
 
   /**
-   * Push params to Waf with given limits
+   * Push params to Waf with given limits. Exactly one of {@code persistentData} and {@code
+   * ephemeralData} must be non-null; see {@link #runWafContext}.
    *
    * @param persistentData data to push to Waf
    * @param ephemeralData data to push to Waf
@@ -92,6 +103,12 @@ public class WafContext implements Closeable {
       throws AbstractWafException {
     if (limits == null) {
       throw new IllegalArgumentException("limits must be provided");
+    }
+    if ((persistentData == null) == (ephemeralData == null)) {
+      // Reject before serializing anything: libddwaf 2.x has no combined mode, and
+      // runWafContext() would otherwise reject this too, but only after persistentData has
+      // already been serialized into this.lease's arena, with no way to roll that back.
+      throw new InvalidArgumentWafException(WafErrorCode.INVALID_ARGUMENT.getCode());
     }
     try {
       long before = System.nanoTime();
@@ -126,10 +143,10 @@ public class WafContext implements Closeable {
 
           result = runWafContext(persistentBuffer, ephemeralBuffer, newLimits, metrics);
         } finally {
-          // Keep lease/ephemeralLease strongly reachable past the ddwaf_run JNI boundary.
-          // The JIT may elide references to this.lease and ephemeralLease after the last
-          // Java-visible use, letting the GC Cleaner free the underlying native memory while
-          // ddwaf_run is still executing (observed on ZGC Generational, JDK 21.0.8+/JDK 25).
+          // Keep lease/ephemeralLease strongly reachable past the ddwaf_context_eval JNI
+          // boundary. The JIT may elide references to this.lease and ephemeralLease after the
+          // last Java-visible use, letting the GC Cleaner free the underlying native memory
+          // while the WAF is still reading it (observed on ZGC Generational, JDK 21.0.8+/25).
           // Volatile writes are memory barriers the JIT cannot remove. Placed in finally so
           // they run on both normal and exceptional returns. See: APPSEC-62784
           leaseFenceSink = this.lease;

--- a/src/main/java/com/datadog/ddwaf/WafContext.java
+++ b/src/main/java/com/datadog/ddwaf/WafContext.java
@@ -67,7 +67,7 @@ public class WafContext implements Closeable {
    * context itself ({@code ddwaf_context_eval}), while ephemeral data is evaluated against a
    * throw-away subcontext ({@code ddwaf_subcontext_init}/{@code eval}/{@code destroy}). libddwaf
    * 2.x has no combined mode, and each evaluation yields its own result, so passing both (or
-   * neither) fails with {@link com.datadog.ddwaf.exception.InvalidArgumentWafException}.
+   * neither) fails with {@link InvalidArgumentWafException}.
    */
   private native Waf.ResultWithData runWafContext(
       ByteBuffer persistentBuffer,

--- a/src/test/groovy/com/datadog/ddwaf/BadRuleTests.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/BadRuleTests.groovy
@@ -20,7 +20,7 @@ class BadRuleTests implements WafTrait {
   @Test
   void 'no events'() {
     // libddwaf 1.27.0+ now accepts empty configurations instead of throwing an exception
-    wafDiagnostics = builder.addOrUpdateConfig('test', [version: '0.0', events: []])
+    wafDiagnostics = builder.addOrUpdateConfig('test', [version: '2.1', rules: []])
     assert wafDiagnostics != null
     assert wafDiagnostics.numConfigOK == 0
     assert wafDiagnostics.numConfigError == 0

--- a/src/test/groovy/com/datadog/ddwaf/BasicTests.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/BasicTests.groovy
@@ -8,11 +8,13 @@
 
 package com.datadog.ddwaf
 
+import com.datadog.ddwaf.exception.InvalidRuleSetException
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import org.junit.Test
 
 import static Waf.ResultWithData
+import static groovy.test.GroovyAssert.shouldFail
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.contains
 import static org.hamcrest.Matchers.containsInAnyOrder
@@ -28,8 +30,8 @@ class BasicTests implements WafTrait {
   }
 
   @Test
-  void 'test running basic rule v1_0'() {
-    def ruleSet = ARACHNI_ATOM_V1_0
+  void 'test running basic rule with a simple ruleset'() {
+    def ruleSet = ARACHNI_ATOM_SIMPLE
 
     wafDiagnostics = builder.addOrUpdateConfig('test', ruleSet)
     assert wafDiagnostics.rules.loaded == ['arachni_rule']
@@ -204,7 +206,7 @@ class BasicTests implements WafTrait {
 
   @Test
   void 'test with array of string lists'() {
-    def ruleSet = ARACHNI_ATOM_V1_0
+    def ruleSet = ARACHNI_ATOM_SIMPLE
     wafDiagnostics = builder.addOrUpdateConfig('test', ruleSet)
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
@@ -219,7 +221,7 @@ class BasicTests implements WafTrait {
 
   @Test
   void 'test with array'() {
-    def ruleSet = ARACHNI_ATOM_V1_0
+    def ruleSet = ARACHNI_ATOM_SIMPLE
     wafDiagnostics = builder.addOrUpdateConfig('test', ruleSet)
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
@@ -231,7 +233,7 @@ class BasicTests implements WafTrait {
 
   @Test
   void 'test null argument'() {
-    def ruleSet = ARACHNI_ATOM_V1_0
+    def ruleSet = ARACHNI_ATOM_SIMPLE
     wafDiagnostics = builder.addOrUpdateConfig('test', ruleSet)
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
@@ -243,7 +245,7 @@ class BasicTests implements WafTrait {
 
   @Test
   void 'test boolean arguments'() {
-    def ruleSet = ARACHNI_ATOM_V1_0
+    def ruleSet = ARACHNI_ATOM_SIMPLE
     wafDiagnostics = builder.addOrUpdateConfig('test', ruleSet)
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
@@ -258,7 +260,7 @@ class BasicTests implements WafTrait {
 
   @Test
   void 'test unencodable arguments'() {
-    def ruleSet = ARACHNI_ATOM_V1_0
+    def ruleSet = ARACHNI_ATOM_SIMPLE
     wafDiagnostics = builder.addOrUpdateConfig('test', ruleSet)
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
@@ -288,38 +290,39 @@ class BasicTests implements WafTrait {
   }
 
   @Test
-  void 'handles ruleset without addresses'() {
+  void 'a rule without addresses is rejected'() {
+    // With the v1 configuration schema gone (libddwaf 2.0), a rule with no inputs can no longer
+    // be expressed: the v2.1 parser rejects it, so a ruleset without addresses is not
+    // representable any more.
     def ruleSet = new JsonSlurper().parseText '''
             {
-              "version": "1.0",
-              "events": [
+              "version": "2.1",
+              "rules": [
                 {
                   "id": "arachni_rule",
                   "name": "Arachni",
+                  "tags": {
+                    "type": "arachni_detection"
+                  },
                   "conditions": [
                     {
-                      "operation": "match_regex",
+                      "operator": "match_regex",
                       "parameters": {
                         "inputs": [],
                         "regex": "Arachni"
                       }
                     }
-                  ],
-                  "tags": {
-                    "type": "arachni_detection"
-                  },
-                  "action": "record"
+                  ]
                 }
               ]
             }'''
-    wafDiagnostics = builder.addOrUpdateConfig('test', ruleSet as Map<String, Object>)
-    handle = builder.buildWafHandleInstance()
-    context = new WafContext(handle)
-    assert handle.knownAddresses.length == 0
-
-    final params = ['server.request.headers.no_cookies': ['user-agent': 'Arachni']]
-    ResultWithData res = context.run(params, limits, metrics)
-    assertThat res.result, is(Waf.Result.OK)
+    def exc = shouldFail(InvalidRuleSetException) {
+      builder.addOrUpdateConfig('test', ruleSet as Map<String, Object>)
+    }
+    wafDiagnostics = exc.wafDiagnostics
+    assert wafDiagnostics.numConfigOK == 0
+    assert wafDiagnostics.numConfigError == 1
+    assert wafDiagnostics.allErrors.keySet() == ['empty non-optional argument'] as Set
   }
 
   @Test

--- a/src/test/groovy/com/datadog/ddwaf/ByteBufferSerializerTests.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/ByteBufferSerializerTests.groovy
@@ -48,6 +48,26 @@ class ByteBufferSerializerTests extends ByteBufferSerializerTestsBase {
   }
 
   @Test
+  void 'can serialize strings around the small string boundary'() {
+    // strings of up to 14 UTF-8 bytes are stored inline in the ddwaf_object
+    // (DDWAF_OBJ_SMALL_STRING), longer ones through a pointer (DDWAF_OBJ_STRING).
+    // Both encodings must read back identically
+    for (int len in 1..16) {
+      String s = 'a' * len
+      assertSerializeValue(s, "<STRING> $s")
+    }
+  }
+
+  @Test
+  void 'can serialize multibyte strings around the small string boundary'() {
+    // the boundary is on UTF-8 bytes, not on characters: 'é' is 2 bytes and '👍' is 4
+    assertSerializeValue('é' * 7, '<STRING> ' + 'é' * 7)     // 14 bytes: small string
+    assertSerializeValue('é' * 8, '<STRING> ' + 'é' * 8)     // 16 bytes: pointer string
+    assertSerializeValue('👍' * 3 + 'ab', '<STRING> ' + '👍' * 3 + 'ab')  // 14 bytes
+    assertSerializeValue('👍' * 3 + 'abc', '<STRING> ' + '👍' * 3 + 'abc') // 15 bytes
+  }
+
+  @Test
   void 'can serialize a CharBuffer'() {
     char[] storedBody = 'my string' as char[]
     CharBuffer cb = CharBuffer.wrap(storedBody, 0, storedBody.length)
@@ -358,6 +378,26 @@ class ByteBufferSerializerTests extends ByteBufferSerializerTestsBase {
           c: <STRING> d
         '''
     assertThat res, is(exp)
+    assertMetrics(0, 0, 0)
+  }
+
+  @Test
+  void 'round-trips against a tree built with the official ddwaf_object API'() {
+    // ByteBufferSerializer hand-rolls libddwaf's ddwaf_object layout; build the same tree with
+    // the official C API and check both are read back identically
+    def value = [
+      sstr: 'small',
+      str: 'a string longer than 14 bytes',
+      signed: -42L,
+      bool: true,
+      float: 8.5d,
+      null: null,
+      array: [1L, 'two'],
+      map: [inner: 'value'],
+    ]
+    lease = serializer.serialize(value, metrics)
+    String res = Waf.pwArgsBufferToString(lease.firstPWArgsByteBuffer)
+    assertThat res, is(Waf.referenceObjectTreeToString())
     assertMetrics(0, 0, 0)
   }
 

--- a/src/test/groovy/com/datadog/ddwaf/ByteBufferSerializerTests.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/ByteBufferSerializerTests.groovy
@@ -402,6 +402,21 @@ class ByteBufferSerializerTests extends ByteBufferSerializerTestsBase {
   }
 
   @Test
+  void 'observes the native 65535 container size limit'() {
+    // libddwaf 2.x stores container size/capacity in a uint16_t; a container
+    // larger than 65535 entries must be truncated before crossing the JNI
+    // boundary, or the size field wraps around and libddwaf reads a corrupt
+    // object graph. This is separate from the configurable maxElements limit.
+    maxElements = 100_000
+    def bigList = (1..70_000).toList()
+    lease = serializer.serialize([my_key: bigList], metrics)
+
+    String res = Waf.pwArgsBufferToString(lease.firstPWArgsByteBuffer)
+    assertThat res.count('<SIGNED>'), is(65535)
+    assertMetrics(0, 1, 0)
+  }
+
+  @Test
   void 'first pwargs buffer with nothing written'() {
     lease = ByteBufferSerializer.blankLease
     shouldFail(IllegalStateException) { lease.firstPWArgsByteBuffer }

--- a/src/test/groovy/com/datadog/ddwaf/CharSequenceSerializationTests.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/CharSequenceSerializationTests.groovy
@@ -22,24 +22,27 @@ class CharSequenceSerializationTests implements WafTrait {
 
   static final Map REQ_BODY_ATOM = (Map) new JsonSlurper().parseText('''
         {
-          "version": "1.0",
-          "events": [
+          "version": "2.1",
+          "rules": [
             {
               "id": "req_body_rule",
               "name": "Request body capturing",
-              "conditions": [
-                {
-                  "operation": "match_regex",
-                  "parameters": {
-                    "inputs": ["server.request.body.raw"],
-                    "regex": "my string"
-                  }
-                }
-              ],
               "tags": {
                 "type": "req_body_detection"
               },
-              "action": "record"
+              "conditions": [
+                {
+                  "operator": "match_regex",
+                  "parameters": {
+                    "inputs": [
+                      {
+                        "address": "server.request.body.raw"
+                      }
+                    ],
+                    "regex": "my string"
+                  }
+                }
+              ]
             }
           ]
         }

--- a/src/test/groovy/com/datadog/ddwaf/LimitsTests.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/LimitsTests.groovy
@@ -130,41 +130,49 @@ class LimitsTests implements WafTrait {
   void 'runBudgetInUs is observed'() {
     def atom = new JsonSlurper().parseText('''
           {
-            "version": "1.0",
-            "events": [
+            "version": "2.1",
+            "rules": [
               {
                 "id": "arachni_rule1",
                 "name": "Arachni",
-                "conditions": [
-                  {
-                    "operation": "match_regex",
-                    "parameters": {
-                      "inputs": ["server.request.headers.no_cookies:user-agent"],
-                      "regex": "Arachni"
-                    }
-                  }
-                ],
                 "tags": {
                   "type": "arachni_detection1"
                 },
-                "action": "record"
+                "conditions": [
+                  {
+                    "operator": "match_regex",
+                    "parameters": {
+                      "inputs": [
+                        {
+                          "address": "server.request.headers.no_cookies",
+                          "key_path": ["user-agent"]
+                        }
+                      ],
+                      "regex": "Arachni"
+                    }
+                  }
+                ]
               },
               {
                 "id": "arachni_rule2",
                 "name": "Arachni",
-                "conditions": [
-                  {
-                    "operation": "match_regex",
-                    "parameters": {
-                      "inputs": ["server.request.headers.no_cookies:user-agent"],
-                      "regex": "Arachni"
-                    }
-                  }
-                ],
                 "tags": {
                   "type": "arachni_detection2"
                 },
-                "action": "record"
+                "conditions": [
+                  {
+                    "operator": "match_regex",
+                    "parameters": {
+                      "inputs": [
+                        {
+                          "address": "server.request.headers.no_cookies",
+                          "key_path": ["user-agent"]
+                        }
+                      ],
+                      "regex": "Arachni"
+                    }
+                  }
+                ]
               }
             ]
           }''')

--- a/src/test/groovy/com/datadog/ddwaf/ObfuscationTests.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/ObfuscationTests.groovy
@@ -48,7 +48,7 @@ class ObfuscationTests implements WafTrait {
 
     def json = slurper.parseText(awd.data)
 
-    assert json[0].rule_matches[0]['parameters'][0].key_path == ['user-agent', '0']
+    assert json[0].rule_matches[0]['parameters'][0].key_path == ['user-agent', 0]
     assert json[0].rule_matches[0]['parameters'][0].value == 'Arachni/v1 password=<Redacted>'
     assert json[0].rule_matches[0]['parameters'][0].highlight == ['<Redacted>']
   }

--- a/src/test/groovy/com/datadog/ddwaf/RulesCompatTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/RulesCompatTest.groovy
@@ -659,7 +659,7 @@ class RulesCompatTest implements WafTrait {
     def result = context.run(params, limits, metrics)
 
     assert result.result == Waf.Result.MATCH
-    assert !result.attributes.isEmpty()
+    assert !result.attributes.empty
     assert !result.events, 'events must be false for a match triggered only by attributes'
     assert result.data == null
   }

--- a/src/test/groovy/com/datadog/ddwaf/RulesCompatTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/RulesCompatTest.groovy
@@ -641,6 +641,50 @@ class RulesCompatTest implements WafTrait {
   }
 
   @Test
+  void 'match produced only by attributes reports no events'() {
+    // In libddwaf 2.x a MATCH can be produced by attributes/actions alone, with an empty
+    // events array. ResultWithData.events must reflect that and be false.
+    wafDiagnostics = builder.addOrUpdateConfig('test', TRACE_TAGGING_RULESET)
+    assert wafDiagnostics.numConfigOK == 1
+
+    handle = builder.buildWafHandleInstance()
+    context = new WafContext(handle)
+
+    def params = [
+      'server.request.headers.no_cookies': [
+        'user-agent': 'TraceTagging/v1'
+      ]
+    ]
+
+    def result = context.run(params, limits, metrics)
+
+    assert result.result == Waf.Result.MATCH
+    assert !result.attributes.isEmpty()
+    assert !result.events, 'events must be false for a match triggered only by attributes'
+    assert result.data == null
+  }
+
+  @Test
+  void 'no match reports no events'() {
+    wafDiagnostics = builder.addOrUpdateConfig('test', TRACE_TAGGING_RULESET)
+    assert wafDiagnostics.numConfigOK == 1
+
+    handle = builder.buildWafHandleInstance()
+    context = new WafContext(handle)
+
+    def params = [
+      'server.request.headers.no_cookies': [
+        'user-agent': 'Harmless/1.0'
+      ]
+    ]
+
+    def result = context.run(params, limits, metrics)
+
+    assert result.result == Waf.Result.OK
+    assert !result.events, 'events must be false when there is no match'
+  }
+
+  @Test
   void 'test trace tagging rule with attributes, no keep and event'() {
     def rulesetWithTraceTaggingEvent = TRACE_TAGGING_EVENT_RULESET
 

--- a/src/test/groovy/com/datadog/ddwaf/WafBuilderTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/WafBuilderTest.groovy
@@ -56,7 +56,7 @@ class WafBuilderTest implements WafTrait {
 
   @Test
   void 'handle after adding one configuration'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     assert wafDiagnostics.numConfigOK == 1
     handle = builder.buildWafHandleInstance()
     assert handle != null
@@ -64,13 +64,13 @@ class WafBuilderTest implements WafTrait {
 
   @Test
   void 'remove an existing configuration'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     assert wafDiagnostics.numConfigOK == 1
     builder.removeConfig('test')
     shouldFail {
       builder.buildWafHandleInstance()
     }
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     assert wafDiagnostics.numConfigOK == 1
     handle = builder.buildWafHandleInstance()
     assert handle != null
@@ -78,7 +78,7 @@ class WafBuilderTest implements WafTrait {
 
   @Test
   void 'remove a non-existing configuration throws'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     assert wafDiagnostics.numConfigOK == 1
     shouldFail(UnclassifiedWafException) {
       builder.removeConfig('non-existing')
@@ -117,14 +117,14 @@ class WafBuilderTest implements WafTrait {
   @Test
   void 'add configuration with empty path throws'() {
     shouldFail(IllegalArgumentException) {
-      builder.addOrUpdateConfig('', ARACHNI_ATOM_V1_0)
+      builder.addOrUpdateConfig('', ARACHNI_ATOM_SIMPLE)
     }
   }
 
   @Test
   void 'add configuration with null path throws'() {
     shouldFail(IllegalArgumentException) {
-      builder.addOrUpdateConfig(null, ARACHNI_ATOM_V1_0)
+      builder.addOrUpdateConfig(null, ARACHNI_ATOM_SIMPLE)
     }
   }
 
@@ -152,7 +152,7 @@ class WafBuilderTest implements WafTrait {
   @Test
   void 'update existing configuration'() {
     // Add initial configuration
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     assert wafDiagnostics.numConfigOK == 1
 
     // Update with new configuration
@@ -172,11 +172,11 @@ class WafBuilderTest implements WafTrait {
   void 'multiple configurations can be added'() {
     try {
       // Add first configuration
-      wafDiagnostics = builder.addOrUpdateConfig('test1', ARACHNI_ATOM_V1_0)
+      wafDiagnostics = builder.addOrUpdateConfig('test1', ARACHNI_ATOM_SIMPLE)
       assert wafDiagnostics.numConfigOK == 1
 
       // Add second configuration - this might throw depending on compatibility of the configs
-      wafDiagnostics = builder.addOrUpdateConfig('test2', ARACHNI_ATOM_V1_0)
+      wafDiagnostics = builder.addOrUpdateConfig('test2', ARACHNI_ATOM_SIMPLE)
 
       // Should be able to build a handle with both configurations
       handle = builder.buildWafHandleInstance()

--- a/src/test/groovy/com/datadog/ddwaf/WafContextTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/WafContextTest.groovy
@@ -43,7 +43,7 @@ class WafContextTest implements WafTrait {
 
   @Test
   void 'creating WafContext with valid WafHandle succeeds'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
 
     context = new WafContext(handle)
@@ -52,7 +52,7 @@ class WafContextTest implements WafTrait {
 
   @Test
   void 'run with null limits throws IllegalArgumentException'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
 
@@ -65,7 +65,7 @@ class WafContextTest implements WafTrait {
 
   @Test
   void 'run with null parameters throws InvalidArgumentWafException'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
 
@@ -76,7 +76,7 @@ class WafContextTest implements WafTrait {
 
   @Test
   void 'throw an exception when both persistent and ephemeral are null in wafContext'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
 
@@ -87,7 +87,7 @@ class WafContextTest implements WafTrait {
 
   @Test
   void 'run with empty parameters returns valid result'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
 
@@ -101,7 +101,7 @@ class WafContextTest implements WafTrait {
 
   @Test
   void 'context run with matching rule returns MATCH result'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
 
@@ -114,7 +114,7 @@ class WafContextTest implements WafTrait {
 
   @Test
   void 'run with very short timeout throws TimeoutWafException'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
 
@@ -128,7 +128,7 @@ class WafContextTest implements WafTrait {
 
   @Test
   void 'run updates metrics if provided'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
 
@@ -189,22 +189,36 @@ class WafContextTest implements WafTrait {
   }
 
   @Test
-  void 'run with persistent and ephemeral data succeeds'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+  void 'run with persistent and then ephemeral data succeeds'() {
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
 
-    def persistentData = ['persistent': 'data']
-    def ephemeralData = ['ephemeral': 'data']
+    def persistentResult = context.run(['persistent': 'data'], limits, metrics)
+    assert persistentResult != null
+    assert persistentResult.result == Waf.Result.OK
 
-    def result = context.run(persistentData, ephemeralData, limits, metrics)
-    assert result != null
-    assert result.result == Waf.Result.OK
+    def ephemeralResult = context.runEphemeral(['ephemeral': 'data'], limits, metrics)
+    assert ephemeralResult != null
+    assert ephemeralResult.result == Waf.Result.OK
+  }
+
+  @Test
+  void 'passing both persistent and ephemeral data in the same call is rejected'() {
+    // libddwaf 2.x evaluates ephemeral data through a subcontext, which yields its own result;
+    // there is no combined mode any more
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
+    handle = builder.buildWafHandleInstance()
+    context = new WafContext(handle)
+
+    shouldFail(InvalidArgumentWafException) {
+      context.run(['persistent': 'data'], ['ephemeral': 'data'], limits, metrics)
+    }
   }
 
   @Test
   void 'runEphemeral with data succeeds'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
     context = new WafContext(handle)
 

--- a/src/test/groovy/com/datadog/ddwaf/WafDiagnosticsTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/WafDiagnosticsTest.groovy
@@ -18,7 +18,7 @@ class WafDiagnosticsTest implements WafTrait {
 
   @Test
   void 'WafDiagnostics returns expected values for addOrUpdateConfig'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
 
     assert wafDiagnostics != null
     assert wafDiagnostics.rules != null

--- a/src/test/groovy/com/datadog/ddwaf/WafHandleTest.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/WafHandleTest.groovy
@@ -25,31 +25,30 @@ class WafHandleTest implements WafTrait {
   void 'Reference sample should pass'() {
     def rule = '''
           {
-            "version": "1.0",
-            "events": [
+            "version": "2.1",
+            "rules": [
               {
                 "id": "arachni_rule",
                 "name": "Arachni",
+                "tags": {
+                  "type": "flow1"
+                },
                 "conditions": [
                   {
-                    "operation": "match_regex",
+                    "operator": "match_regex",
                     "parameters": {
-                      "inputs": ["arg1"],
+                      "inputs": [{ "address": "arg1" }],
                       "regex": ".*"
                     }
                   },
                   {
-                    "operation": "match_regex",
+                    "operator": "match_regex",
                     "parameters": {
-                      "inputs": ["arg2"],
+                      "inputs": [{ "address": "arg2" }],
                       "regex": ".*"
                     }
                   }
-                ],
-                "tags": {
-                  "type": "flow1"
-                },
-                "action": "record"
+                ]
               }
             ]
           }
@@ -143,7 +142,7 @@ class WafHandleTest implements WafTrait {
 
   @Test
   void 'waf handle is online after creation'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
 
     assert handle.online
@@ -151,7 +150,7 @@ class WafHandleTest implements WafTrait {
 
   @Test
   void 'waf handle is offline after closing'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
     handle.close()
 
@@ -160,7 +159,7 @@ class WafHandleTest implements WafTrait {
 
   @Test
   void 'waf handle can be closed multiple times safely'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
 
     // First close
@@ -174,7 +173,7 @@ class WafHandleTest implements WafTrait {
 
   @Test
   void 'waf handle has known addresses'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
 
     String[] addresses = handle.knownAddresses
@@ -194,7 +193,7 @@ class WafHandleTest implements WafTrait {
 
   @Test
   void 'knownAddresses throws exception after handle is closed'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
     handle.close()
 
@@ -218,7 +217,7 @@ class WafHandleTest implements WafTrait {
 
   @Test
   void 'different waf handle instances for same ruleset have same addresses'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
 
     // Create two separate instances
     def handle1 = builder.buildWafHandleInstance()
@@ -240,7 +239,7 @@ class WafHandleTest implements WafTrait {
 
   @Test
   void 'waf handle thread safety for read operations'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
 
     // Simulate multiple threads accessing read methods
@@ -268,7 +267,7 @@ class WafHandleTest implements WafTrait {
 
   @Test
   void 'waf handle thread safety for close operation'() {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle = builder.buildWafHandleInstance()
 
     // Simulate multiple threads trying to close the handle
@@ -290,7 +289,7 @@ class WafHandleTest implements WafTrait {
   @Test
   void 'updating ruleset configuration works correctly'() {
     // First add a basic ruleset
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
 
     // Then update with a different ruleset
     wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_BLOCK)

--- a/src/test/groovy/com/datadog/ddwaf/WafTrait.groovy
+++ b/src/test/groovy/com/datadog/ddwaf/WafTrait.groovy
@@ -20,26 +20,37 @@ import static org.hamcrest.Matchers.is
 @CompileStatic
 trait WafTrait extends JNITrait {
 
-  static final Map ARACHNI_ATOM_V1_0 = (Map) new JsonSlurper().parseText('''
+  /**
+   * Minimal ruleset with an unanchored regex and no metadata. libddwaf 2.0 dropped support for the
+   * legacy v1.0 configuration schema, so this is the v2.1 equivalent of the former
+   * ARACHNI_ATOM_V1_0 fixture.
+   */
+  static final Map ARACHNI_ATOM_SIMPLE = (Map) new JsonSlurper().parseText('''
         {
-          "version": "1.0",
-          "events": [
+          "version": "2.1",
+          "rules": [
             {
               "id": "arachni_rule",
               "name": "Arachni",
-              "conditions": [
-                {
-                  "operation": "match_regex",
-                  "parameters": {
-                    "inputs": ["server.request.headers.no_cookies:user-agent"],
-                    "regex": "Arachni"
-                  }
-                }
-              ],
               "tags": {
                 "type": "arachni_detection"
               },
-              "action": "record"
+              "conditions": [
+                {
+                  "operator": "match_regex",
+                  "parameters": {
+                    "inputs": [
+                      {
+                        "address": "server.request.headers.no_cookies",
+                        "key_path": [
+                          "user-agent"
+                        ]
+                      }
+                    ],
+                    "regex": "Arachni"
+                  }
+                }
+              ]
             }
           ]
         }''')
@@ -237,7 +248,7 @@ trait WafTrait extends JNITrait {
 
   @SuppressWarnings(value = ['UnnecessaryCast', 'UnsafeImplementationAsMap'])
   Waf.ResultWithData runRules(Object data) {
-    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_V1_0)
+    wafDiagnostics = builder.addOrUpdateConfig('test', ARACHNI_ATOM_SIMPLE)
     handle?.close()
     context?.close()
     handle = builder.buildWafHandleInstance()


### PR DESCRIPTION
### What does this PR do?

Bumps the vendored `libddwaf` from 1.30.0 to 2.0.1 across all four version
sources of truth (submodule pointer, `libddwafVersion` in
`.github/workflows/actions.yml`, `Waf.LIB_VERSION`, and the artifact version
in `build.gradle`), and rewrites the JNI binding to follow libddwaf's major
C API change.

### Motivation

Jira ticket: [APPSEC-69428](https://datadoghq.atlassian.net/browse/APPSEC-69428)

### Description of the Change

libddwaf 2.x replaces the API surface this binding hand-rolls against:

- **Explicit allocators.** `ddwaf_context_init`/`ddwaf_object_destroy` now take
  an allocator. Input objects keep using `alloc = NULL` (view-only, zero-copy)
  - the 1:1 replacement for the old `config.free_fn = NULL` pattern.
- **`ddwaf_object`/`ddwaf_object_kv` layout change.** `ddwaf_object` stays
  16 bytes; map entries now live in a new 32-byte `ddwaf_object_kv` struct
  (key + value side by side) instead of the key living on the child object.
  `ByteBufferSerializer`'s zero-copy binary layout was rewritten for this,
  with `_Static_assert`s pinning every offset in `ddwaf_layout.h` and a
  runtime cross-check (`ByteBufferSerializer.checkNativeLayout()`) so a
  future libddwaf bump fails loudly instead of silently corrupting memory.
- **`ddwaf_run` -> `ddwaf_context_eval`.** Persistent evaluation moves to the
  new function; ephemeral evaluation is replaced entirely by
  `ddwaf_subcontext_init`/`eval`/`destroy` (subcontexts), replacing the old
  ephemeral-buffer-per-call flow in `WafContext`.
- **`ddwaf_config` removed.** Obfuscator regex configuration now goes through
  `ddwaf_builder_add_or_update_config` instead.
- **New `uint16` container size/capacity.** Containers are capped at 65535
  entries (previously effectively unbounded); insertion loops in
  `waf_jni.c`/`ByteBufferSerializer.java` now clamp to this limit, logging at
  `WARN` when truncation actually occurs (a regression test now covers the
  Java-side clamp as well).
- Manual index-based map iteration replaced with the official
  `ddwaf_object_get_size`/`at_key`/`at_value` accessors on the result-reading
  path (`output.c`).
- `run(persistentData, ephemeralData, ...)` now rejects the combined
  persistent+ephemeral case in Java, before any serialization happens
  (libddwaf 2.x has no combined-evaluation mode).
- v1.0 ruleset test fixtures converted to schema 2.1 (v1.0 support was
  removed upstream).

### Additional Notes

**Behavior changes worth flagging for consumers (e.g. dd-trace-java):**

- The `key_path` array indices in event JSON are now emitted as JSON
  numbers instead of strings (matches libddwaf 2.x's own event schema; no
  key was renamed). Confirmed via `ObfuscationTests.groovy`, where the
  expected `key_path` for an array index changed from `'0'` to `0`. Any
  consumer that deserializes this JSON into a strictly-typed field (e.g.
  `List<String>`) will need to update that type - please check before
  upgrading.
- Calling the WAF with both persistent and ephemeral data at once (or
  neither) now throws `InvalidArgumentWafException` earlier: during Java
  serialization rather than after a native call. This path isn't reachable
  through the public `run()`/`runEphemeral()` API, only via the private
  combined-mode method, so it shouldn't affect existing callers.
- Container/config entries beyond 65535 elements are now truncated (a new
  hard limit from libddwaf 2.x's `uint16` `ddwaf_object` size field); this
  is logged at `WARN`.

This is a **minor** version bump (17.4.0 to 17.5.0), not a major one. No
Java method signature changed, and the one confirmed behavior change
(`key_path` index encoding) fails loudly for any strictly-typed consumer
rather than silently corrupting data, so it doesn't rise to the level of a
breaking change under this repo's versioning policy (see `AGENTS.md`).
That said, it's a real wire-format change, called out explicitly above so
downstream consumers can check their own parsing code before adopting this
version.


[APPSEC-69428]: https://datadoghq.atlassian.net/browse/APPSEC-69428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ